### PR TITLE
Js/strat periods simple

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeStruct"
 uuid = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Truls.Flatberg <Truls.Flatberg@sintef.no>"]
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -50,3 +50,56 @@ function Base.iterate(itr::SimpleTimes{T}, state) where {T}
     state == itr.len && return nothing
     return SimplePeriod{T}(state + 1, itr.duration[state+1]), state + 1
 end
+
+"""
+    StrategicPeriodSimple <: TimePeriod
+
+Time period for iteration of strategic periods.
+"""
+struct StrategicPeriodSimple{S,OP} <: TimePeriod
+    duration::S
+    operational::OP
+end
+
+isfirst(sp::StrategicPeriodSimple) = sp.sp == 1
+Base.show(io::IO, sp::StrategicPeriodSimple) = print(io, "sp1")
+
+duration(sp::StrategicPeriodSimple) = sp.duration
+_strat_per(sp::StrategicPeriodSimple) = 1
+
+struct StratPeriodsSimple{T}
+    ts::SimpleTimes{T}
+end
+
+"""
+    strat_periods(ts::SimpleTimes)
+
+Iteration through the strategic periods of a 'SimpleTimes' structure.
+"""
+strat_periods(ts::SimpleTimes) = StratPeriodsSimple(ts)
+Base.length(sps::StratPeriodsSimple) = 1
+
+function Base.iterate(sps::StratPeriodsSimple)
+    return StrategicPeriodSimple(1, sps.ts.duration), 1
+end
+
+function Base.iterate(sps::StratPeriodsSimple, state)
+    return nothing
+end
+
+Base.length(itr::StrategicPeriodSimple) = length(itr.operational)
+function Base.eltype(::Type{StrategicPeriodSimple{S,OP}}) where {S,OP}
+    return SimplePeriod
+end
+
+# Function for defining the time periods when iterating through a strategic period when
+# the time structure is provided as SimpleTimes
+function Base.iterate(itr::StrategicPeriodSimple{S,OP}) where {S,OP}
+    next = iterate(itr.operational)
+    return SimplePeriod(1, next[1]), 1
+end
+function Base.iterate(itr::StrategicPeriodSimple{S,OP}, state) where {S,OP}
+    state == length(itr) && return nothing
+    next = iterate(itr.operational, state + 1)
+    return SimplePeriod(state + 1, next[1]), state + 1
+end

--- a/src/stochastic.jl
+++ b/src/stochastic.jl
@@ -90,7 +90,7 @@ _oper(t::ScenarioPeriod) = _oper(t.period)
 _opscen(t::ScenarioPeriod) = t.sc
 
 """
-    struct OperationalScenario 
+    struct OperationalScenario
 A structure representing a single operational scenario supporting
 iteration over its time periods.
 """
@@ -117,7 +117,7 @@ end
 Base.length(os::OperationalScenario) = length(os.operational)
 Base.eltype(::Type{OperationalScenario}) = ScenarioPeriod
 
-# Iteration through scenarios 
+# Iteration through scenarios
 struct OpScens{T}
     ts::OperationalScenarios{T}
 end
@@ -155,7 +155,9 @@ end
 
 # Allow SimpleTimes to behave as one operational scenario
 opscenarios(ts::SimpleTimes) = [ts]
+opscenarios(ts::StrategicPeriodSimple) = [ts]
 probability(ts::SimpleTimes) = 1.0
+probability(ts::StrategicPeriodSimple) = 1.0
 
 struct ReprOperationalScenario{T,OP<:TimeStructure{T}} <: TimeStructure{T}
     rper::Int64

--- a/src/twolevel.jl
+++ b/src/twolevel.jl
@@ -260,7 +260,7 @@ function remaining(sp::StrategicPeriod, ts::TwoLevel)
 end
 
 # Let SimpleTimes and OperationalScenarios behave as a TwoLevel time structure with one strategic period
-strat_periods(ts::SimpleTimes) = [ts]
+# strat_periods(ts::SimpleTimes) = [ts]
 strat_periods(ts::OperationalScenarios) = [ts]
 
 # Allow both strategic_periods and strat_periods as function name

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -40,6 +40,11 @@ function Base.last(ts::SimpleTimes)
     return SimplePeriod(ts.len, ts.duration[ts.len])
 end
 
+function Base.last(ts::StrategicPeriodSimple)
+    len = length(ts)
+    return SimplePeriod(len, ts.operational[len])
+end
+
 function Base.last(_::OperationalScenarios)
     return error("last() not implemented for OperationalScenarios")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,18 @@ end
     @test first(ts) == TimeStruct.SimplePeriod(1, 4)
     @test duration(first(ts)) == 4
     @test duration(ts) == 24
+
+    sps = strat_periods(ts)
+    sp = collect(sps)[1]
+    @test length(sps) == 1
+    @test last(sp) == last(ts)
+    @test duration(sp) == 1
+
+    ops1 = collect(ts)
+    ops2 = collect(sp)
+    @test length(ops1) == length(ops2)
+    @test first(ops1) == first(ops2)
+    @test ops1 == ops2
 end
 
 @testitem "SimpleTimes with units" begin


### PR DESCRIPTION
Copied from original MR at gitlab (from Julian Strauss):
This merge request changes the behaviour of the function strat_periods(ts::SimpleTimes) through the introduction of the types StratPeriodsSimple and StrategicPeriodSimple.
The main aim is to create a type that returns a given duration that is independent of the number of operational periods. In that respect, it can be seen as a solution to the issue [Bugfix: strat_periods of SimpleTimes](https://gitlab.sintef.no/julia-one-sintef/timestruct.jl/-/issues/5).
The names of the new types is up to debate. Similarly, it can be useful to include some additional concepts from TwoLevel like op_per_strat or comparable to avoid adjusting parameters in models.