### PR TITLE
Improved profile composite types

### DIFF
--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -5,7 +5,7 @@ abstract type TimeProfile{T} end
 
 Time profile with a constant value for all time periods
 """
-struct FixedProfile{T} <: TimeProfile{T}
+struct FixedProfile{T<:Duration} <: TimeProfile{T}
     val::T
 end
 
@@ -24,7 +24,7 @@ period.
 If too few values are provided, the last provided value will be
 repeated.
 """
-struct OperationalProfile{T} <: TimeProfile{T}
+struct OperationalProfile{T<:Duration} <: TimeProfile{T}
     vals::Vector{T}
 end
 
@@ -43,7 +43,7 @@ Time profile with a separate time profile for each strategic period.
 If too few profiles are provided, the last given profile will be
 repeated.
 """
-struct StrategicProfile{T,P<:TimeProfile{T}} <: TimeProfile{T}
+struct StrategicProfile{T<:Duration,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
 end
 
@@ -84,7 +84,7 @@ end
 
 Time profile with a separate time profile for each scenario
 """
-struct ScenarioProfile{T,P<:TimeProfile{T}} <: TimeProfile{T}
+struct ScenarioProfile{T<:Duration,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
 end
 
@@ -130,7 +130,7 @@ Time profile with a separate time profile for each representative period.
 If too few profiles are provided, the last given profile will be
 repeated.
 """
-struct RepresentativeProfile{T,P<:TimeProfile{T}} <: TimeProfile{T}
+struct RepresentativeProfile{T<:Duration,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
 end
 
@@ -168,7 +168,7 @@ function Base.getindex(ssp::StrategicStochasticProfile, i::TimePeriod)
     return ssp.vals[_strat_per(i)][_branch(i)]
 end
 
-struct DynamicStochasticProfile{T} <: TimeProfile{T}
+struct DynamicStochasticProfile{T<:Duration} <: TimeProfile{T}
     vals::Vector{<:Vector{<:TimeProfile{T}}}
 end
 function Base.getindex(ssp::DynamicStochasticProfile, i::TimePeriod)

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -1,9 +1,14 @@
 abstract type TimeProfile{T} end
 
 """
-    FixedProfile(val)
+    FixedProfile(val<:Duration)
 
-Time profile with a constant value for all time periods
+Time profile with a constant value for all time periods.
+
+## Example
+```julia
+profile = FixedProfile(5)
+```
 """
 struct FixedProfile{T<:Duration} <: TimeProfile{T}
     val::T
@@ -17,12 +22,16 @@ function Base.getindex(
 end
 
 """
-    OperationalProfile
-Time profile with a value that varies with the operational time
-period.
+    OperationalProfile(vals::Vector{T}) where {T<:Duration}
 
-If too few values are provided, the last provided value will be
-repeated.
+Time profile with a value that varies with the operational time period.
+
+If too few values are provided, the last provided value will be repeated.
+
+## Example
+```julia
+profile = OperationalProfile([1, 2, 3, 4, 5])
+```
 """
 struct OperationalProfile{T<:Duration} <: TimeProfile{T}
     vals::Vector{T}
@@ -36,23 +45,25 @@ function Base.getindex(
 end
 
 """
-    StrategicProfile(vals)
+    StrategicProfile(vals::Vector{P}) where {T<:Duration, P<:TimeProfile{T}}
+    StrategicProfile(vals::Vector{<:Number})
 
 Time profile with a separate time profile for each strategic period.
+If the input is a
 
-If too few profiles are provided, the last given profile will be
-repeated.
+If too few profiles are provided, the last given profile will be repeated.
+
+## Example
+```julia
+# Varying values in each strategic period
+profile = StrategicProfile([OperationalProfile([1, 2]), OperationalProfile([3, 4, 5])])
+ # The same value in each strategic period
+profile = StrategicProfile([1, 2, 3, 4, 5])
+```
 """
 struct StrategicProfile{T<:Duration,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
 end
-
-"""
-    StrategicProfile(vals::Vector{<:Number})
-
-Create a strategic profile with a fixed value for each strategic
-period.
-"""
 function StrategicProfile(vals::Vector{<:Number})
     return StrategicProfile([FixedProfile(v) for v in vals])
 end
@@ -76,19 +87,24 @@ function Base.getindex(
 end
 
 """
-    ScenarioProfile(vals)
+    ScenarioProfile(vals::Vector{P}) where {T<:Duration, P<:TimeProfile{T}}
+    ScenarioProfile(vals::Vector{<:Number})
 
-Time profile with a separate time profile for each scenario
+Time profile with a separate time profile for each scenario.
+
+If too few profiles are provided, the last given profile will be repeated.
+
+## Example
+```julia
+# Varying values in each strategic period
+profile = ScenarioProfile([OperationalProfile([1, 2]), OperationalProfile([3, 4, 5])])
+ # The same value in each strategic period
+profile = ScenarioProfile([1, 2, 3, 4, 5])
+```
 """
 struct ScenarioProfile{T<:Duration,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
 end
-
-"""
-    ScenarioProfile(vals::Vector{<:Number})
-
-Create a scenario profile with a fixed value for each operational scenario.
-"""
 function ScenarioProfile(vals::Vector{<:Number})
     return ScenarioProfile([FixedProfile(v) for v in vals])
 end
@@ -111,23 +127,24 @@ function Base.getindex(
 end
 
 """
-    RepresentativeProfile(vals)
+    RepresentativeProfile(vals::Vector{P}) where {T<:Duration, P<:TimeProfile{T}}
+    RepresentativeProfile(vals::Vector{<:Number})
 
 Time profile with a separate time profile for each representative period.
 
-If too few profiles are provided, the last given profile will be
-repeated.
+If too few profiles are provided, the last given profile will be repeated.
+
+## Example
+```julia
+# Varying values in each strategic period
+profile = RepresentativeProfile([OperationalProfile([1, 2]), OperationalProfile([3, 4, 5])])
+ # The same value in each strategic period
+profile = RepresentativeProfile([1, 2, 3, 4, 5])
+```
 """
 struct RepresentativeProfile{T<:Duration,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
 end
-
-"""
-    RepresentativeProfile(vals::Vector{<:Number})
-
-Create a representative profile with a fixed value for each representative
-period.
-"""
 function RepresentativeProfile(vals::Vector{<:Number})
     return RepresentativeProfile([FixedProfile(v) for v in vals])
 end

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -75,10 +75,6 @@ function Base.getindex(
     return _value_lookup(StrategicIndexable(T), sp, period)
 end
 
-function StrategicProfile(vals::Vector{T}) where {T}
-    return StrategicProfile([FixedProfile{T}(v) for v in vals])
-end
-
 """
     ScenarioProfile(vals)
 
@@ -112,14 +108,6 @@ function Base.getindex(
     period::T,
 ) where {T<:Union{TimePeriod,TimeStructure}}
     return _value_lookup(ScenarioIndexable(T), sp, period)
-end
-
-function ScenarioProfile(vals::Vector{Vector{T}}) where {T}
-    v = Vector{OperationalProfile{T}}()
-    for scv in vals
-        push!(v, OperationalProfile{T}(scv))
-    end
-    return ScenarioProfile(v)
 end
 
 """

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -49,7 +49,6 @@ end
     StrategicProfile(vals::Vector{<:Duration})
 
 Time profile with a separate time profile for each strategic period.
-If the input is a
 
 If too few profiles are provided, the last given profile will be repeated.
 
@@ -96,9 +95,9 @@ If too few profiles are provided, the last given profile will be repeated.
 
 ## Example
 ```julia
-# Varying values in each strategic period
+# Varying values in each operational scenario
 profile = ScenarioProfile([OperationalProfile([1, 2]), OperationalProfile([3, 4, 5])])
- # The same value in each strategic period
+ # The same value in each operational scenario
 profile = ScenarioProfile([1, 2, 3, 4, 5])
 ```
 """
@@ -136,9 +135,9 @@ If too few profiles are provided, the last given profile will be repeated.
 
 ## Example
 ```julia
-# Varying values in each strategic period
+# Varying values in each representative period
 profile = RepresentativeProfile([OperationalProfile([1, 2]), OperationalProfile([3, 4, 5])])
- # The same value in each strategic period
+ # The same value in each representative period
 profile = RepresentativeProfile([1, 2, 3, 4, 5])
 ```
 """

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -46,7 +46,7 @@ end
 
 """
     StrategicProfile(vals::Vector{P}) where {T<:Duration, P<:TimeProfile{T}}
-    StrategicProfile(vals::Vector{<:Number})
+    StrategicProfile(vals::Vector{<:Duration})
 
 Time profile with a separate time profile for each strategic period.
 If the input is a
@@ -64,7 +64,7 @@ profile = StrategicProfile([1, 2, 3, 4, 5])
 struct StrategicProfile{T<:Duration,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
 end
-function StrategicProfile(vals::Vector{<:Number})
+function StrategicProfile(vals::Vector{<:Duration})
     return StrategicProfile([FixedProfile(v) for v in vals])
 end
 
@@ -88,7 +88,7 @@ end
 
 """
     ScenarioProfile(vals::Vector{P}) where {T<:Duration, P<:TimeProfile{T}}
-    ScenarioProfile(vals::Vector{<:Number})
+    ScenarioProfile(vals::Vector{<:Duration})
 
 Time profile with a separate time profile for each scenario.
 
@@ -105,7 +105,7 @@ profile = ScenarioProfile([1, 2, 3, 4, 5])
 struct ScenarioProfile{T<:Duration,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
 end
-function ScenarioProfile(vals::Vector{<:Number})
+function ScenarioProfile(vals::Vector{<:Duration})
     return ScenarioProfile([FixedProfile(v) for v in vals])
 end
 
@@ -128,7 +128,7 @@ end
 
 """
     RepresentativeProfile(vals::Vector{P}) where {T<:Duration, P<:TimeProfile{T}}
-    RepresentativeProfile(vals::Vector{<:Number})
+    RepresentativeProfile(vals::Vector{<:Duration})
 
 Time profile with a separate time profile for each representative period.
 
@@ -145,7 +145,7 @@ profile = RepresentativeProfile([1, 2, 3, 4, 5])
 struct RepresentativeProfile{T<:Duration,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
 end
-function RepresentativeProfile(vals::Vector{<:Number})
+function RepresentativeProfile(vals::Vector{<:Duration})
     return RepresentativeProfile([FixedProfile(v) for v in vals])
 end
 
@@ -196,59 +196,59 @@ function Base.getindex(TP::TimeProfile, inds::Any)
 end
 
 import Base: +, -, *, /
-+(a::FixedProfile{T}, b::Number) where {T<:Number} = FixedProfile(a.val + b)
-function +(a::OperationalProfile{T}, b::Number) where {T<:Number}
++(a::FixedProfile{T}, b::Number) where {T<:Duration} = FixedProfile(a.val + b)
+function +(a::OperationalProfile{T}, b::Number) where {T<:Duration}
     return OperationalProfile(a.vals .+ b)
 end
-function +(a::StrategicProfile{T}, b::Number) where {T<:Number}
+function +(a::StrategicProfile{T}, b::Number) where {T<:Duration}
     return StrategicProfile(a.vals .+ b)
 end
-function +(a::ScenarioProfile{T}, b::Number) where {T<:Number}
+function +(a::ScenarioProfile{T}, b::Number) where {T<:Duration}
     return ScenarioProfile(a.vals .+ b)
 end
-function +(a::RepresentativeProfile{T}, b::Number) where {T<:Number}
+function +(a::RepresentativeProfile{T}, b::Number) where {T<:Duration}
     return RepresentativeProfile(a.vals .+ b)
 end
-+(a::Number, b::TimeProfile{T}) where {T<:Number} = b + a
--(a::FixedProfile{T}, b::Number) where {T<:Number} = FixedProfile(a.val - b)
-function -(a::OperationalProfile{T}, b::Number) where {T<:Number}
++(a::Number, b::TimeProfile{T}) where {T<:Duration} = b + a
+-(a::FixedProfile{T}, b::Number) where {T<:Duration} = FixedProfile(a.val - b)
+function -(a::OperationalProfile{T}, b::Number) where {T<:Duration}
     return OperationalProfile(a.vals .- b)
 end
-function -(a::StrategicProfile{T}, b::Number) where {T<:Number}
+function -(a::StrategicProfile{T}, b::Number) where {T<:Duration}
     return StrategicProfile(a.vals .- b)
 end
-function -(a::ScenarioProfile{T}, b::Number) where {T<:Number}
+function -(a::ScenarioProfile{T}, b::Number) where {T<:Duration}
     return ScenarioProfile(a.vals .- b)
 end
-function -(a::RepresentativeProfile{T}, b::Number) where {T<:Number}
+function -(a::RepresentativeProfile{T}, b::Number) where {T<:Duration}
     return RepresentativeProfile(a.vals .- b)
 end
 
-*(a::FixedProfile{T}, b::Number) where {T<:Number} = FixedProfile(a.val .* b)
-function *(a::OperationalProfile{T}, b::Number) where {T<:Number}
+*(a::FixedProfile{T}, b::Number) where {T<:Duration} = FixedProfile(a.val .* b)
+function *(a::OperationalProfile{T}, b::Number) where {T<:Duration}
     return OperationalProfile(a.vals .* b)
 end
-function *(a::StrategicProfile{T}, b::Number) where {T<:Number}
+function *(a::StrategicProfile{T}, b::Number) where {T<:Duration}
     return StrategicProfile(a.vals .* b)
 end
-function *(a::ScenarioProfile{T}, b::Number) where {T<:Number}
+function *(a::ScenarioProfile{T}, b::Number) where {T<:Duration}
     return ScenarioProfile(a.vals .* b)
 end
-function *(a::RepresentativeProfile{T}, b::Number) where {T<:Number}
+function *(a::RepresentativeProfile{T}, b::Number) where {T<:Duration}
     return RepresentativeProfile(a.vals .* b)
 end
 
-*(a::Number, b::TimeProfile{T}) where {T<:Number} = b * a
-/(a::FixedProfile{T}, b::Number) where {T<:Number} = FixedProfile(a.val / b)
-function /(a::OperationalProfile{T}, b::Number) where {T<:Number}
+*(a::Number, b::TimeProfile{T}) where {T<:Duration} = b * a
+/(a::FixedProfile{T}, b::Number) where {T<:Duration} = FixedProfile(a.val / b)
+function /(a::OperationalProfile{T}, b::Number) where {T<:Duration}
     return OperationalProfile(a.vals ./ b)
 end
-function /(a::StrategicProfile{T}, b::Number) where {T<:Number}
+function /(a::StrategicProfile{T}, b::Number) where {T<:Duration}
     return StrategicProfile(a.vals ./ b)
 end
-function /(a::ScenarioProfile{T}, b::Number) where {T<:Number}
+function /(a::ScenarioProfile{T}, b::Number) where {T<:Duration}
     return ScenarioProfile(a.vals ./ b)
 end
-function /(a::RepresentativeProfile{T}, b::Number) where {T<:Number}
+function /(a::RepresentativeProfile{T}, b::Number) where {T<:Duration}
     return RepresentativeProfile(a.vals ./ b)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -816,7 +816,7 @@ end
 
     @test_throws ErrorException scp["dummy"]
 
-    scp2 = ScenarioProfile([[1, 1, 2], [3], [4, 5]])
+    scp2 = ScenarioProfile([OperationalProfile([1, 1, 2]), FixedProfile(3), OperationalProfile([4, 5])])
     @test sum(scp2[t] for t in tsc) == 201
 
     ssp = StrategicProfile([scp, scp2])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -816,7 +816,11 @@ end
 
     @test_throws ErrorException scp["dummy"]
 
-    scp2 = ScenarioProfile([OperationalProfile([1, 1, 2]), FixedProfile(3), OperationalProfile([4, 5])])
+    scp2 = ScenarioProfile([
+        OperationalProfile([1, 1, 2]),
+        FixedProfile(3),
+        OperationalProfile([4, 5]),
+    ])
     @test sum(scp2[t] for t in tsc) == 201
 
     ssp = StrategicProfile([scp, scp2])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -883,6 +883,16 @@ end
     @test dsp[ops[4]] == 5
 end
 
+@testitem "Profiles constructors" begin
+    # Checking the input type
+    @test_throws MethodError FixedProfile("wrong_input")
+    @test_throws MethodError OperationalProfile("wrong_input")
+    @test_throws MethodError ScenarioProfile("wrong_input")
+    @test_throws MethodError RepresentativeProfile("wrong_input")
+    @test_throws MethodError StrategicProfile("wrong_input")
+    @test_throws MethodError StrategicProfile("StrategicStochasticProfile")
+end
+
 @testitem "Profiles and strategic periods" begin
     profile = StrategicProfile([1, 2, 3])
 


### PR DESCRIPTION
So far, it was possible to create time profiles that were not following the philosophy of the package. As an example, it was possible to define a

```julia
FixedProfile([10, 11, 12])
```

which is not desired.

Similarly, it was possible to declare a

```julia
StrategicProfile([[10], [11], [12]])
```

Neither of the profiles are representing the intended purpose. To this end, we add a dependency for the parametric input of a timeprofile to be limited to `Duration`.

I updated as well the docstrings for a unified approach.

The changes were tested using the tests of [`EnergyModelsBase`](https://energymodelsx.github.io/EnergyModelsBase.jl/stable/) and [`EnergyModelsInvestments`](https://energymodelsx.github.io/EnergyModelsInvestments.jl/stable/) to assess the impact.