### PR TITLE
Improvement of TimeStructure types

### DIFF
--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -1,7 +1,7 @@
 abstract type TimeProfile{T} end
 
 """
-    FixedProfile(val<:Duration)
+    FixedProfile(val<:Number)
 
 Time profile with a constant value for all time periods.
 
@@ -10,7 +10,7 @@ Time profile with a constant value for all time periods.
 profile = FixedProfile(5)
 ```
 """
-struct FixedProfile{T<:Duration} <: TimeProfile{T}
+struct FixedProfile{T<:Number} <: TimeProfile{T}
     val::T
 end
 
@@ -22,7 +22,7 @@ function Base.getindex(
 end
 
 """
-    OperationalProfile(vals::Vector{T}) where {T<:Duration}
+    OperationalProfile(vals::Vector{T}) where {T<:Number}
 
 Time profile with a value that varies with the operational time period.
 
@@ -33,7 +33,7 @@ If too few values are provided, the last provided value will be repeated.
 profile = OperationalProfile([1, 2, 3, 4, 5])
 ```
 """
-struct OperationalProfile{T<:Duration} <: TimeProfile{T}
+struct OperationalProfile{T<:Number} <: TimeProfile{T}
     vals::Vector{T}
 end
 
@@ -45,8 +45,8 @@ function Base.getindex(
 end
 
 """
-    StrategicProfile(vals::Vector{P}) where {T<:Duration, P<:TimeProfile{T}}
-    StrategicProfile(vals::Vector{<:Duration})
+    StrategicProfile(vals::Vector{P}) where {T<:Number, P<:TimeProfile{T}}
+    StrategicProfile(vals::Vector{<:Number})
 
 Time profile with a separate time profile for each strategic period.
 
@@ -60,10 +60,10 @@ profile = StrategicProfile([OperationalProfile([1, 2]), OperationalProfile([3, 4
 profile = StrategicProfile([1, 2, 3, 4, 5])
 ```
 """
-struct StrategicProfile{T<:Duration,P<:TimeProfile{T}} <: TimeProfile{T}
+struct StrategicProfile{T<:Number,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
 end
-function StrategicProfile(vals::Vector{<:Duration})
+function StrategicProfile(vals::Vector{<:Number})
     return StrategicProfile([FixedProfile(v) for v in vals])
 end
 
@@ -86,8 +86,8 @@ function Base.getindex(
 end
 
 """
-    ScenarioProfile(vals::Vector{P}) where {T<:Duration, P<:TimeProfile{T}}
-    ScenarioProfile(vals::Vector{<:Duration})
+    ScenarioProfile(vals::Vector{P}) where {T<:Number, P<:TimeProfile{T}}
+    ScenarioProfile(vals::Vector{<:Number})
 
 Time profile with a separate time profile for each scenario.
 
@@ -101,10 +101,10 @@ profile = ScenarioProfile([OperationalProfile([1, 2]), OperationalProfile([3, 4,
 profile = ScenarioProfile([1, 2, 3, 4, 5])
 ```
 """
-struct ScenarioProfile{T<:Duration,P<:TimeProfile{T}} <: TimeProfile{T}
+struct ScenarioProfile{T<:Number,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
 end
-function ScenarioProfile(vals::Vector{<:Duration})
+function ScenarioProfile(vals::Vector{<:Number})
     return ScenarioProfile([FixedProfile(v) for v in vals])
 end
 
@@ -126,8 +126,8 @@ function Base.getindex(
 end
 
 """
-    RepresentativeProfile(vals::Vector{P}) where {T<:Duration, P<:TimeProfile{T}}
-    RepresentativeProfile(vals::Vector{<:Duration})
+    RepresentativeProfile(vals::Vector{P}) where {T<:Number, P<:TimeProfile{T}}
+    RepresentativeProfile(vals::Vector{<:Number})
 
 Time profile with a separate time profile for each representative period.
 
@@ -141,10 +141,10 @@ profile = RepresentativeProfile([OperationalProfile([1, 2]), OperationalProfile(
 profile = RepresentativeProfile([1, 2, 3, 4, 5])
 ```
 """
-struct RepresentativeProfile{T<:Duration,P<:TimeProfile{T}} <: TimeProfile{T}
+struct RepresentativeProfile{T<:Number,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
 end
-function RepresentativeProfile(vals::Vector{<:Duration})
+function RepresentativeProfile(vals::Vector{<:Number})
     return RepresentativeProfile([FixedProfile(v) for v in vals])
 end
 
@@ -172,7 +172,7 @@ function Base.getindex(ssp::StrategicStochasticProfile, i::TimePeriod)
     return ssp.vals[_strat_per(i)][_branch(i)]
 end
 
-struct DynamicStochasticProfile{T<:Duration} <: TimeProfile{T}
+struct DynamicStochasticProfile{T<:Number} <: TimeProfile{T}
     vals::Vector{<:Vector{<:TimeProfile{T}}}
 end
 function Base.getindex(ssp::DynamicStochasticProfile, i::TimePeriod)
@@ -195,59 +195,59 @@ function Base.getindex(TP::TimeProfile, inds::Any)
 end
 
 import Base: +, -, *, /
-+(a::FixedProfile{T}, b::Number) where {T<:Duration} = FixedProfile(a.val + b)
-function +(a::OperationalProfile{T}, b::Number) where {T<:Duration}
++(a::FixedProfile{T}, b::Number) where {T<:Number} = FixedProfile(a.val + b)
+function +(a::OperationalProfile{T}, b::Number) where {T<:Number}
     return OperationalProfile(a.vals .+ b)
 end
-function +(a::StrategicProfile{T}, b::Number) where {T<:Duration}
+function +(a::StrategicProfile{T}, b::Number) where {T<:Number}
     return StrategicProfile(a.vals .+ b)
 end
-function +(a::ScenarioProfile{T}, b::Number) where {T<:Duration}
+function +(a::ScenarioProfile{T}, b::Number) where {T<:Number}
     return ScenarioProfile(a.vals .+ b)
 end
-function +(a::RepresentativeProfile{T}, b::Number) where {T<:Duration}
+function +(a::RepresentativeProfile{T}, b::Number) where {T<:Number}
     return RepresentativeProfile(a.vals .+ b)
 end
-+(a::Number, b::TimeProfile{T}) where {T<:Duration} = b + a
--(a::FixedProfile{T}, b::Number) where {T<:Duration} = FixedProfile(a.val - b)
-function -(a::OperationalProfile{T}, b::Number) where {T<:Duration}
++(a::Number, b::TimeProfile{T}) where {T<:Number} = b + a
+-(a::FixedProfile{T}, b::Number) where {T<:Number} = FixedProfile(a.val - b)
+function -(a::OperationalProfile{T}, b::Number) where {T<:Number}
     return OperationalProfile(a.vals .- b)
 end
-function -(a::StrategicProfile{T}, b::Number) where {T<:Duration}
+function -(a::StrategicProfile{T}, b::Number) where {T<:Number}
     return StrategicProfile(a.vals .- b)
 end
-function -(a::ScenarioProfile{T}, b::Number) where {T<:Duration}
+function -(a::ScenarioProfile{T}, b::Number) where {T<:Number}
     return ScenarioProfile(a.vals .- b)
 end
-function -(a::RepresentativeProfile{T}, b::Number) where {T<:Duration}
+function -(a::RepresentativeProfile{T}, b::Number) where {T<:Number}
     return RepresentativeProfile(a.vals .- b)
 end
 
-*(a::FixedProfile{T}, b::Number) where {T<:Duration} = FixedProfile(a.val .* b)
-function *(a::OperationalProfile{T}, b::Number) where {T<:Duration}
+*(a::FixedProfile{T}, b::Number) where {T<:Number} = FixedProfile(a.val .* b)
+function *(a::OperationalProfile{T}, b::Number) where {T<:Number}
     return OperationalProfile(a.vals .* b)
 end
-function *(a::StrategicProfile{T}, b::Number) where {T<:Duration}
+function *(a::StrategicProfile{T}, b::Number) where {T<:Number}
     return StrategicProfile(a.vals .* b)
 end
-function *(a::ScenarioProfile{T}, b::Number) where {T<:Duration}
+function *(a::ScenarioProfile{T}, b::Number) where {T<:Number}
     return ScenarioProfile(a.vals .* b)
 end
-function *(a::RepresentativeProfile{T}, b::Number) where {T<:Duration}
+function *(a::RepresentativeProfile{T}, b::Number) where {T<:Number}
     return RepresentativeProfile(a.vals .* b)
 end
 
-*(a::Number, b::TimeProfile{T}) where {T<:Duration} = b * a
-/(a::FixedProfile{T}, b::Number) where {T<:Duration} = FixedProfile(a.val / b)
-function /(a::OperationalProfile{T}, b::Number) where {T<:Duration}
+*(a::Number, b::TimeProfile{T}) where {T<:Number} = b * a
+/(a::FixedProfile{T}, b::Number) where {T<:Number} = FixedProfile(a.val / b)
+function /(a::OperationalProfile{T}, b::Number) where {T<:Number}
     return OperationalProfile(a.vals ./ b)
 end
-function /(a::StrategicProfile{T}, b::Number) where {T<:Duration}
+function /(a::StrategicProfile{T}, b::Number) where {T<:Number}
     return StrategicProfile(a.vals ./ b)
 end
-function /(a::ScenarioProfile{T}, b::Number) where {T<:Duration}
+function /(a::ScenarioProfile{T}, b::Number) where {T<:Number}
     return ScenarioProfile(a.vals ./ b)
 end
-function /(a::RepresentativeProfile{T}, b::Number) where {T<:Duration}
+function /(a::RepresentativeProfile{T}, b::Number) where {T<:Number}
     return RepresentativeProfile(a.vals ./ b)
 end

--- a/src/representative.jl
+++ b/src/representative.jl
@@ -1,11 +1,11 @@
 """
     struct RepresentativePeriods{S<:Duration,T,OP<:TimeStructure{T}} <: TimeStructure{T}
 
-    RepresentativePeriods(len::Integer, duration::S, period_share::Vector{Float64}, rep_periods::Vector{OP}) where {S<:Duration, T, OP<:TimeStructure{T}}
+    RepresentativePeriods(len::Integer, duration::S, period_share::Vector{<:Real}, rep_periods::Vector{OP}) where {S<:Duration, T, OP<:TimeStructure{T}}
     RepresentativePeriods(len::Integer, duration::S, rep_periods::TimeStructure{T}) where {S<:Duration, T}
 
-    RepresentativePeriods(duration::S, period_share::Vector{Float64}, rep_periods::Vector{<:TimeStructure{T}}) where {S<:Duration, T}
-    RepresentativePeriods(duration::S, period_share::Vector{Float64}, rep_periods::TimeStructure{T}) where {S<:Duration, T}
+    RepresentativePeriods(duration::S, period_share::Vector{<:Real}, rep_periods::Vector{<:TimeStructure{T}}) where {S<:Duration, T}
+    RepresentativePeriods(duration::S, period_share::Vector{<:Real}, rep_periods::TimeStructure{T}) where {S<:Duration, T}
 
     RepresentativePeriods(duration::S, rep_periods::Vector{<:TimeStructure{T}}) where {S<:Duration, T}
 
@@ -23,10 +23,11 @@ is attributed to it.
     - If the field `period_share` is not specified, it assigns the same probability to each
       representative period.
     - It is possible that `sum(period_share)` is larger or smaller than 1. This can lead to
-      problems in your application. Hence, it is advised to scale it. We provide currently a
-      warning as it would correspond to a breaking change.
+      problems in your application. Hence, it is advised to scale it. Currently, a warning
+      will be given if the period shares do not sum to one as an automatic scaling will
+      correspond to a breaking change.
     - If you include [`OperationalScenarios`](@ref) in your time structure, it is important
-      that you the scenarios are within the representative periods, and note the other way.
+      that the scenarios are within the representative periods, and not the other way.
 
 ### Example
 ```julia
@@ -41,14 +42,14 @@ RepresentativePeriods(8760, [SimpleTimes(24, 1), SimpleTimes(24,1)])
 """
 struct RepresentativePeriods{S<:Duration,T,OP<:TimeStructure{T}} <:
        TimeStructure{T}
-    len::Integer
+    len::Int
     duration::S
     period_share::Vector{Float64}
     rep_periods::Vector{OP}
     function RepresentativePeriods(
         len::Integer,
         duration::S,
-        period_share::Vector{Float64},
+        period_share::Vector{<:Real},
         rep_periods::Vector{OP},
     ) where {S<:Duration,T,OP<:TimeStructure{T}}
         if len > length(period_share)
@@ -69,7 +70,7 @@ struct RepresentativePeriods{S<:Duration,T,OP<:TimeStructure{T}} <:
                 "This can lead to unexpected behaviour."
             )
         end
-        return new{S,T,OP}(len, duration, period_share, rep_periods)
+        return new{S,T,OP}(len, duration, convert(Vector{Float64}, period_share), rep_periods)
     end
 end
 function RepresentativePeriods(
@@ -86,7 +87,7 @@ function RepresentativePeriods(
 end
 function RepresentativePeriods(
     duration::S,
-    period_share::Vector{Float64},
+    period_share::Vector{<:Real},
     rep_periods::Vector{<:TimeStructure{T}},
 ) where {S<:Duration,T}
     return RepresentativePeriods(
@@ -98,7 +99,7 @@ function RepresentativePeriods(
 end
 function RepresentativePeriods(
     duration::S,
-    period_share::Vector{Float64},
+    period_share::Vector{<:Real},
     rep_periods::TimeStructure{T},
 ) where {S<:Duration,T}
     return RepresentativePeriods(
@@ -167,7 +168,7 @@ Base.eltype(::Type{RepresentativePeriods}) = ReprPeriod
 # A single operational time period used when iterating through
 # a represenative period
 struct ReprPeriod{T} <: TimePeriod
-    rp::Integer
+    rp::Int
     period::T
     mult::Float64
 end

--- a/src/representative.jl
+++ b/src/representative.jl
@@ -70,7 +70,12 @@ struct RepresentativePeriods{S<:Duration,T,OP<:TimeStructure{T}} <:
                 "This can lead to unexpected behaviour."
             )
         end
-        return new{S,T,OP}(len, duration, convert(Vector{Float64}, period_share), rep_periods)
+        return new{S,T,OP}(
+            len,
+            duration,
+            convert(Vector{Float64}, period_share),
+            rep_periods,
+        )
     end
 end
 function RepresentativePeriods(

--- a/src/representative.jl
+++ b/src/representative.jl
@@ -39,7 +39,8 @@ RepresentativePeriods(2, 8760, SimpleTimes(24, 1))
 RepresentativePeriods(8760, [SimpleTimes(24, 1), SimpleTimes(24,1)])
 ```
 """
-struct RepresentativePeriods{S<:Duration,T,OP<:TimeStructure{T}} <: TimeStructure{T}
+struct RepresentativePeriods{S<:Duration,T,OP<:TimeStructure{T}} <:
+       TimeStructure{T}
     len::Integer
     duration::S
     period_share::Vector{Float64}

--- a/src/representative.jl
+++ b/src/representative.jl
@@ -1,5 +1,14 @@
 """
-    RepresentativePeriods <: TimeStructure
+    struct RepresentativePeriods{S<:Duration,T,OP<:TimeStructure{T}} <: TimeStructure{T}
+
+    RepresentativePeriods(len::Integer, duration::S, period_share::Vector{Float64}, rep_periods::Vector{OP}) where {S<:Duration, T, OP<:TimeStructure{T}}
+    RepresentativePeriods(len::Integer, duration::S, rep_periods::TimeStructure{T}) where {S<:Duration, T}
+
+    RepresentativePeriods(duration::S, period_share::Vector{Float64}, rep_periods::Vector{<:TimeStructure{T}}) where {S<:Duration, T}
+    RepresentativePeriods(duration::S, period_share::Vector{Float64}, rep_periods::TimeStructure{T}) where {S<:Duration, T}
+
+    RepresentativePeriods(duration::S, rep_periods::Vector{<:TimeStructure{T}}) where {S<:Duration, T}
+
 
 Time structure that allows a time period to be represented by one or more
 shorter representative time periods.
@@ -9,17 +18,105 @@ used for each representative period. In addition, each representative period
 has an associated share that specifies how much of the total duration that
 is attributed to it.
 
+!!! note
+    - All representative periods must use the same type for the `TimeStructure`.
+    - If the field `period_share` is not specified, it assigns the same probability to each
+      representative period.
+    - It is possible that `sum(period_share)` is larger or smaller than 1. This can lead to
+      problems in your application. Hence, it is advised to scale it. We provide currently a
+      warning as it would correspond to a breaking change.
+    - If you include [`OperationalScenarios`](@ref) in your time structure, it is important
+      that you the scenarios are within the representative periods, and note the other way.
+
 ### Example
 ```julia
 # A year represented by two days with hourly resolution and relative shares of 0.7 and 0.3
-periods = RepresentativePeriods(2, 8760, [0.7, 0.3], [SimpleTimes(24, 1), SimpleTimes(24,1)])
+RepresentativePeriods(8760, [0.7, 0.3], [SimpleTimes(24, 1), SimpleTimes(24,1)])
+RepresentativePeriods(8760, [0.7, 0.3], SimpleTimes(24, 1))
+
+# A year represented by two days with hourly resolution and relative shares of 0.5
+RepresentativePeriods(2, 8760, SimpleTimes(24, 1))
+RepresentativePeriods(8760, [SimpleTimes(24, 1), SimpleTimes(24,1)])
 ```
 """
-struct RepresentativePeriods{S,T,OP<:TimeStructure{T}} <: TimeStructure{T}
-    len::Int
+struct RepresentativePeriods{S<:Duration,T,OP<:TimeStructure{T}} <: TimeStructure{T}
+    len::Integer
     duration::S
     period_share::Vector{Float64}
     rep_periods::Vector{OP}
+    function RepresentativePeriods(
+        len::Integer,
+        duration::S,
+        period_share::Vector{Float64},
+        rep_periods::Vector{OP},
+    ) where {S<:Duration,T,OP<:TimeStructure{T}}
+        if len > length(period_share)
+            throw(
+                ArgumentError(
+                    "The length of `period_share` cannot be less than the field `len` of `RepresentativePeriods`.",
+                ),
+            )
+        elseif len > length(rep_periods)
+            throw(
+                ArgumentError(
+                    "The length of `rep_periods` cannot be less than the field `len` of `RepresentativePeriods`.",
+                ),
+            )
+        elseif sum(period_share) > 1 || sum(period_share) < 1
+            @warn(
+                "The sum of the `period_share` vector is given by $(sum(period_share)). " *
+                "This can lead to unexpected behaviour."
+            )
+        end
+        return new{S,T,OP}(len, duration, period_share, rep_periods)
+    end
+end
+function RepresentativePeriods(
+    len::Integer,
+    duration::S,
+    rep_periods::TimeStructure{T},
+) where {S<:Duration,T}
+    return RepresentativePeriods(
+        len,
+        duration,
+        fill(1.0 / len, len),
+        fill(rep_periods, len),
+    )
+end
+function RepresentativePeriods(
+    duration::S,
+    period_share::Vector{Float64},
+    rep_periods::Vector{<:TimeStructure{T}},
+) where {S<:Duration,T}
+    return RepresentativePeriods(
+        length(rep_periods),
+        duration,
+        period_share,
+        rep_periods,
+    )
+end
+function RepresentativePeriods(
+    duration::S,
+    period_share::Vector{Float64},
+    rep_periods::TimeStructure{T},
+) where {S<:Duration,T}
+    return RepresentativePeriods(
+        length(period_share),
+        duration,
+        period_share,
+        fill(rep_periods, length(period_share)),
+    )
+end
+function RepresentativePeriods(
+    duration::S,
+    rep_periods::Vector{<:TimeStructure{T}},
+) where {S<:Duration,T}
+    return RepresentativePeriods(
+        length(rep_periods),
+        duration,
+        fill(1.0 / length(rep_periods), length(rep_periods)),
+        rep_periods,
+    )
 end
 
 _total_duration(ts::RepresentativePeriods) = ts.duration
@@ -69,7 +166,7 @@ Base.eltype(::Type{RepresentativePeriods}) = ReprPeriod
 # A single operational time period used when iterating through
 # a represenative period
 struct ReprPeriod{T} <: TimePeriod
-    rp::Int
+    rp::Integer
     period::T
     mult::Float64
 end

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -5,8 +5,10 @@
     SimpleTimes(len::Integer, duration::Number)
     SimpleTimes(dur::Vector{T}) where {T<:Number}
 
-A simple time structure conisisting of consecutive time periods of varying duration.
-`SimpleTimes` is always the lowest level in a `TimeStruct` time structure.
+A simple time structure consisting of consecutive time periods of varying duration.
+`SimpleTimes` is always the lowest level in a `TimeStruct` time structure. if used.
+
+An alternative for `SimpleTimes` is [`CalendarTimes`](@ref)
 
 ## Example
 ```julia
@@ -15,7 +17,7 @@ varying = SimpleTimes([2, 2, 2, 4, 10]) # 5 periods of varying length
 ```
 """
 struct SimpleTimes{T} <: TimeStructure{T}
-    len::Integer
+    len::Int
     duration::Vector{T}
     function SimpleTimes(len::Integer, duration::Vector{T}) where {T}
         if len > length(duration)
@@ -44,7 +46,7 @@ _total_duration(st::SimpleTimes) = sum(st.duration)
 A single time period returned when iterating through a SimpleTimes structure
 """
 struct SimplePeriod{T<:Number} <: TimePeriod
-    op::Integer
+    op::Int
     duration::T
 end
 

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -1,16 +1,33 @@
 """
-    struct SimpleTimes <: TimeStructure
-A simple time structure conisisting of consecutive time periods of varying duration
+    struct SimpleTimes{T} <: TimeStructure{T}
+
+    SimpleTimes(len::Integer, duration::Vector{T}) where {T}
+    SimpleTimes(len::Integer, duration::Number)
+    SimpleTimes(dur::Vector{T}) where {T<:Number}
+
+A simple time structure conisisting of consecutive time periods of varying duration.
+`SimpleTimes` is always the lowest level in a `TimeStruct` time structure.
 
 ## Example
 ```julia
 uniform = SimpleTimes(5, 1.0) # 5 periods of equal length
-varying = SimpleTimes([2, 2, 2, 4, 10])
+varying = SimpleTimes([2, 2, 2, 4, 10]) # 5 periods of varying length
 ```
 """
 struct SimpleTimes{T} <: TimeStructure{T}
-    len::Int
+    len::Integer
     duration::Vector{T}
+    function SimpleTimes(len::Integer, duration::Vector{T}) where {T}
+        if len > length(duration)
+            throw(
+                ArgumentError(
+                    "The length of `duration` cannot be less than the length `len` of `SimpleTimes`.",
+                ),
+            )
+        else
+            new{T}(len, duration)
+        end
+    end
 end
 function SimpleTimes(len::Integer, duration::Number)
     return SimpleTimes(len, fill(duration, len))
@@ -27,7 +44,7 @@ _total_duration(st::SimpleTimes) = sum(st.duration)
 A single time period returned when iterating through a SimpleTimes structure
 """
 struct SimplePeriod{T<:Number} <: TimePeriod
-    op::Int
+    op::Integer
     duration::T
 end
 

--- a/src/stochastic.jl
+++ b/src/stochastic.jl
@@ -130,12 +130,7 @@ struct ScenarioPeriod{P} <: TimePeriod where {P<:TimePeriod}
     period::P
 end
 
-function ScenarioPeriod(
-    scenario::Int,
-    prob::Number,
-    multiple::Number,
-    period,
-)
+function ScenarioPeriod(scenario::Int, prob::Number, multiple::Number, period)
     return ScenarioPeriod(
         scenario,
         Base.convert(Float64, prob),

--- a/src/stochastic.jl
+++ b/src/stochastic.jl
@@ -1,7 +1,7 @@
 """
     struct OperationalScenarios{T,OP<:TimeStructure{T}} <: TimeStructure{T}
 
-    OperationalScenarios(len::Int64, scenarios::Vector{OP}, probability::Vector{Float64}) where {T, OP<:TimeStructure{T}
+    OperationalScenarios(len::Integer, scenarios::Vector{OP}, probability::Vector{<:Real}) where {T, OP<:TimeStructure{T}
     OperationalScenarios(len::Integer, oper::TimeStructure{T})
 
     OperationalScenarios(oper::Vector{<:TimeStructure{T}}, prob::Vector)
@@ -15,8 +15,9 @@ and an associated probability. These scenarios are in general represented as
     - All scenarios must use the same type for the duration, _.i.e._, either Integer or Float.
     - If the `probability` is not specified, it assigns the same probability to each scenario.
     - It is possible that `sum(probability)` is larger or smaller than 1. This can lead to
-      problems in your application. Hence, it is advised to scale it. We provide currently a
-      warning as it would correspond to a breaking change.
+      problems in your application. Hence, it is advised to scale it. Currently, a warning
+      will be given if the period shares do not sum to one as an automatic scaling will
+      correspond to a breaking change.
 
 ## Example
 The following examples create a time structure with 2 operational scenarios corresponding to
@@ -29,13 +30,13 @@ OperationalScenarios([day, day])
 ```
 """
 struct OperationalScenarios{T,OP<:TimeStructure{T}} <: TimeStructure{T}
-    len::Integer
+    len::Int
     scenarios::Vector{OP}
     probability::Vector{Float64}
     function OperationalScenarios(
         len::Integer,
         scenarios::Vector{OP},
-        probability::Vector{Float64},
+        probability::Vector{<:Real},
     ) where {T,OP<:TimeStructure{T}}
         if len > length(scenarios)
             throw(
@@ -55,7 +56,7 @@ struct OperationalScenarios{T,OP<:TimeStructure{T}} <: TimeStructure{T}
                 "This can lead to unexpected behaviour."
             )
         end
-        return new{T,OP}(len, scenarios, probability)
+        return new{T,OP}(len, scenarios, convert(Vector{Float64}, probability))
     end
 end
 function OperationalScenarios(len::Integer, oper::TimeStructure{T}) where {T}
@@ -123,14 +124,14 @@ end
 
 # A time period with scenario number and probability
 struct ScenarioPeriod{P} <: TimePeriod where {P<:TimePeriod}
-    sc::Integer
+    sc::Int
     prob::Float64
     multiple::Float64
     period::P
 end
 
 function ScenarioPeriod(
-    scenario::Integer,
+    scenario::Int,
     prob::Number,
     multiple::Number,
     period,

--- a/src/twolevel.jl
+++ b/src/twolevel.jl
@@ -105,7 +105,7 @@ function TwoLevel(
     op_per_strat = 1.0,
 ) where {S,T,OP<:TimeStructure{T}}
     len = length(oper)
-    return TwoLevel{S,T,OP}(len, fill(duration, len), oper, op_per_strat)
+    return TwoLevel(len, fill(duration, len), oper, op_per_strat)
 end
 
 function TwoLevel(

--- a/src/twolevel.jl
+++ b/src/twolevel.jl
@@ -18,8 +18,9 @@ operational decisions. Iterating the structure will go through all operational p
 It is possible to use different time units for the two levels by providing the number
 of operational time units per strategic time unit through the kewyord argument `op_per_strat`.
 
-Potential time structures are [`SimpleTimes`](@ref), [`OperationalScenarios`](@ref), or
-[`RepresentativePeriods`](@ref), as well as combinations of these.
+Potential time structures are [`SimpleTimes`](@ref), [`CalendarTimes`](@ref),
+[`OperationalScenarios`](@ref), or [`RepresentativePeriods`](@ref), as well as combinations
+of these.
 
 !!! danger "Usage of op_per_strat"
     The optional keyword `op_per_strat` is important for the overall calculations.
@@ -33,7 +34,7 @@ Potential time structures are [`SimpleTimes`](@ref), [`OperationalScenarios`](@r
         _total_duration(op) / op_per_strat for op in oper
 
     in which `oper::Vector{<:TimeStructure{T}`. The internal function `_total_duration`
-    corresponds in thgis case to the sum of the duration of all operational periods divided
+    corresponds in this case to the sum of the duration of all operational periods divided
     by the value of the field `op_per_strat`.
 
 Example
@@ -58,7 +59,7 @@ TwoLevel(2, SimpleTimes(24, 1); op_per_strat=8760.0)
 ```
 """
 struct TwoLevel{S<:Duration,T,OP<:TimeStructure{T}} <: TimeStructure{T}
-    len::Integer
+    len::Int
     duration::Vector{S}
     operational::Vector{OP}
     op_per_strat::Float64
@@ -214,7 +215,7 @@ end
 Time period for iteration of a TwoLevel time structure.
 """
 struct OperationalPeriod <: TimePeriod
-    sp::Integer
+    sp::Int
     period::TimePeriod
     multiple::Float64
 end

--- a/src/twolevel.jl
+++ b/src/twolevel.jl
@@ -1,7 +1,7 @@
 """
     struct TwoLevel{S<:Duration,T,OP<:TimeStructure{T}} <: TimeStructure{T}
 
-    TwoLevel(len::Integer, duration::Vector{S}, operational::Vector{OP}, op_per_strat::Float64) where {S<:Number, T, OP<:TimeStructure{T}}
+    TwoLevel(len::Integer, duration::Vector{S}, operational::Vector{OP}, op_per_strat::Float64) where {S<:Duration, T, OP<:TimeStructure{T}}
     TwoLevel(len::Integer, duration::S, oper::TimeStructure{T}; op_per_strat) where {S, T}
     TwoLevel(len::Integer, oper::TimeStructure{T}; op_per_strat) where {T}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -686,11 +686,11 @@ end
         [0.2, 0.8],
         [SimpleTimes(5, 1), SimpleTimes(5, 1)],
     )
-    two_level = TwoLevel(100, [repr, repr, repr]; op_per_strat = 1)
+    two_level = TwoLevel(100, [repr, repr, repr]; op_per_strat = 1.0)
     test_invariants(two_level)
 
     repr = RepresentativePeriods(2, 20, [0.2, 0.8], [opscen, opscen])
-    two_level = TwoLevel(100, [repr, repr]; op_per_strat = 1)
+    two_level = TwoLevel(100, [repr, repr]; op_per_strat = 1.0)
     test_invariants(two_level)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -163,6 +163,14 @@ end
         end
     end
     @test length(pers) == length(ts)
+
+    @test_throws ArgumentError OperationalScenarios(2, [day, week], [1.0])
+    @test_throws ArgumentError OperationalScenarios(2, [day], [0.5, 0.5])
+
+    msg =
+        "The sum of the probablity vector is given by $(2.0). " *
+        "This can lead to unexpected behaviour."
+    @test_logs (:warn, msg) OperationalScenarios([day, day], [0.5, 1.5])
 end
 
 @testitem "RepresentativePeriods" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,6 +32,8 @@ end
     @test first(ts) == TimeStruct.SimplePeriod(1, 4)
     @test duration(first(ts)) == 4
     @test TimeStruct._total_duration(ts) == 24
+
+    @test_throws ArgumentError SimpleTimes(15, [4, 4, 4, 6, 3, 3])
 end
 
 @testitem "SimpleTimes with units" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -164,9 +164,9 @@ end
     end
     @test length(pers) == length(ts)
 
+    # Testing the internal constructor
     @test_throws ArgumentError OperationalScenarios(2, [day, week], [1.0])
     @test_throws ArgumentError OperationalScenarios(2, [day], [0.5, 0.5])
-
     msg =
         "The sum of the probablity vector is given by $(2.0). " *
         "This can lead to unexpected behaviour."
@@ -188,6 +188,36 @@ end
     pers = [t for rp in repr_periods(simple) for t in rp]
     @test pers == collect(simple)
     @test sum(duration(t) * multiple(t) for t in pers) == 10
+
+    # Testing the internal constructor
+    day = SimpleTimes(24, 1)
+    @test_throws ArgumentError RepresentativePeriods(2, 8760, [1.0], [day, day])
+    @test_throws ArgumentError RepresentativePeriods(2, 8760, [0.5, 0.5], [day])
+    msg =
+        "The sum of the `period_share` vector is given by $(2.0). " *
+        "This can lead to unexpected behaviour."
+    @test_logs (:warn, msg) RepresentativePeriods(8760, [0.5, 1.5], [day, day])
+
+    # Testing of the external constructors providing the same case
+    ts_1 = RepresentativePeriods(2, 8760, [0.5, 0.5], [day, day])
+    ts_2 = RepresentativePeriods(2, 8760, day)
+    ts_3 = RepresentativePeriods(8760, [0.5, 0.5], [day, day])
+    ts_4 = RepresentativePeriods(8760, [day, day])
+    ts_5 = RepresentativePeriods(8760, [0.5, 0.5], day)
+
+    fields = fieldnames(typeof(ts_1))
+    @test sum(
+        getfield(ts_1, field) == getfield(ts_2, field) for field in fields
+    ) == length(fields)
+    @test sum(
+        getfield(ts_1, field) == getfield(ts_3, field) for field in fields
+    ) == length(fields)
+    @test sum(
+        getfield(ts_1, field) == getfield(ts_4, field) for field in fields
+    ) == length(fields)
+    @test sum(
+        getfield(ts_1, field) == getfield(ts_5, field) for field in fields
+    ) == length(fields)
 end
 
 @testitem "RepresentativePeriods with units" begin


### PR DESCRIPTION
The aims of this PR is to prevent problems in the construction of `TimeStructure`s. So far, it was possible to create, _e.g._, an inconsistent `Twolevel` instance as we did not provide any internal constructors for identifying problems.

This PR solves this through incorporation of internal constructors.

In addition, it:

* adds constructors to `RepresentativePeriods` to be consistent with other `TimeStructure`s, 
* significantly improves the docstrings, and
* test the individual constructors.

This PR partly closes #17, although there are still open questions regarding the default value of the keyword argument  `op_per_strat` as well as removal of certain constructors. This would however result in breaking changes.

All changes were tested with [`EnergyModelsBase` v0.8](https://github.com/EnergyModelsX/EnergyModelsBase.jl) and [`EnergyModelsInvestments` v0.7](https://github.com/EnergyModelsX/EnergyModelsInvestments.jl).