### PR TITLE
Allow more general T for profiles to support ParametricOptInterface

### DIFF
--- a/docs/src/reference/internal.md
+++ b/docs/src/reference/internal.md
@@ -3,6 +3,7 @@
 ## Internal supertypes
 
 ```@docs
+TimeStruct.TimeStructurePeriod
 TimeStruct.TimeStructInnerIter
 TimeStruct.TimeStructOuterIter
 ```

--- a/ext/TimeStructUnitfulExt.jl
+++ b/ext/TimeStructUnitfulExt.jl
@@ -8,7 +8,7 @@ function TimeStruct.SimpleTimes(dur::Vector{T}, u::Unitful.Units) where {T<:Real
 end
 
 function TimeStruct.TwoLevel(
-    duration::Vector{<:Number},
+    duration::Vector,
     u::Unitful.Units,
     oper::TimeStructure{<:Unitful.Quantity{V,Unitful.𝐓}},
 ) where {V}

--- a/ext/TimeStructUnitfulExt.jl
+++ b/ext/TimeStructUnitfulExt.jl
@@ -8,7 +8,7 @@ function TimeStruct.SimpleTimes(dur::Vector{T}, u::Unitful.Units) where {T<:Real
 end
 
 function TimeStruct.TwoLevel(
-    duration::Vector,
+    duration::Vector{<:Number},
     u::Unitful.Units,
     oper::TimeStructure{<:Unitful.Quantity{V,Unitful.𝐓}},
 ) where {V}

--- a/src/op_scenarios/opscenarios.jl
+++ b/src/op_scenarios/opscenarios.jl
@@ -1,11 +1,11 @@
 """
-    abstract type AbstractOperationalScenario{T} <: TimeStructure{T}
+    abstract type AbstractOperationalScenario{T} <: TimeStructurePeriod{T}
 
 Abstract type used for time structures that represent an operational scenario.
 These periods are obtained when iterating through the operational scenarios of a time
 structure declared by the function [`opscenarios`](@ref).
 """
-abstract type AbstractOperationalScenario{T} <: TimeStructure{T} end
+abstract type AbstractOperationalScenario{T} <: TimeStructurePeriod{T} end
 
 function _opscen(scen::AbstractOperationalScenario)
     return error("_opscen() not implemented for type $(typeof(scen))")

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -53,7 +53,7 @@ struct OperationalProfile{T} <: TimeProfile{T}
             throw(
                 ArgumentError(
                     "It is not possible to use a `Vector{<:Array}` as input " *
-                    "to an `OperationalProfileProfile`.",
+                    "to an `OperationalProfile`.",
                 ),
             )
         else

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -12,6 +12,17 @@ profile = FixedProfile(5)
 """
 struct FixedProfile{T} <: TimeProfile{T}
     val::T
+    function FixedProfile(val::T) where {T}
+        if T <: Array
+            throw(
+                ArgumentError(
+                    "It is not possible to use an `Array` as input to `FixedProfile`."
+                )
+            )
+        else
+            new{T}(val)
+        end
+    end
 end
 
 function Base.getindex(fp::FixedProfile, _::T) where {T<:Union{TimePeriod,TimeStructure}}
@@ -32,6 +43,18 @@ profile = OperationalProfile([1, 2, 3, 4, 5])
 """
 struct OperationalProfile{T} <: TimeProfile{T}
     vals::Vector{T}
+    function OperationalProfile(vals::Vector{T}) where {T}
+        if T <: Array
+            throw(
+                ArgumentError(
+                    "It is not possible to use a `Vector{<:Array}` as input " *
+                    "to an `OperationalProfileProfile`."
+                )
+            )
+        else
+            new{T}(vals)
+        end
+    end
 end
 
 function Base.getindex(
@@ -59,6 +82,18 @@ profile = StrategicProfile([1, 2, 3, 4, 5])
 """
 struct StrategicProfile{T,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
+    function StrategicProfile(vals::Vector{P}) where {T,P<:TimeProfile{T}}
+        if T <: Array
+            throw(
+                ArgumentError(
+                    "It is not possible to use a `Vector{<:Array}` as input " *
+                    "to a `StrategicProfile`."
+                )
+            )
+        else
+            new{T,P}(vals)
+        end
+    end
 end
 function StrategicProfile(vals::Vector)
     return StrategicProfile([FixedProfile(v) for v in vals])
@@ -97,6 +132,18 @@ profile = ScenarioProfile([1, 2, 3, 4, 5])
 """
 struct ScenarioProfile{T,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
+    function ScenarioProfile(vals::Vector{P}) where {T,P<:TimeProfile{T}}
+        if T <: Array
+            throw(
+                ArgumentError(
+                    "It is not possible to use a `Vector{<:Array}` as input " *
+                    "to a `ScenarioProfile`."
+                )
+            )
+        else
+            new{T,P}(vals)
+        end
+    end
 end
 function ScenarioProfile(vals::Vector)
     return ScenarioProfile([FixedProfile(v) for v in vals])
@@ -135,6 +182,18 @@ profile = RepresentativeProfile([1, 2, 3, 4, 5])
 """
 struct RepresentativeProfile{T,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
+    function RepresentativeProfile(vals::Vector{P}) where {T,P<:TimeProfile{T}}
+        if T <: Array
+            throw(
+                ArgumentError(
+                    "It is not possible to use a `Vector{<:Array}` as input " *
+                    "to a `RepresentativeProfile`."
+                )
+            )
+        else
+            new{T,P}(vals)
+        end
+    end
 end
 function RepresentativeProfile(vals::Vector)
     return RepresentativeProfile([FixedProfile(v) for v in vals])
@@ -180,6 +239,18 @@ profile = StrategicStochasticProfile([
 """
 struct StrategicStochasticProfile{T,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{<:Vector{P}}
+    function StrategicStochasticProfile(vals::Vector{<:Vector{P}}) where {T,P<:TimeProfile{T}}
+        if T <: Array
+            throw(
+                ArgumentError(
+                    "It is not possible to use a `Vector{<:Vector{<:Array}}` as input " *
+                    "to a `StrategicStochasticProfile`."
+                )
+            )
+        else
+            new{T,P}(vals)
+        end
+    end
 end
 function StrategicStochasticProfile(vals::Vector{<:Vector})
     return StrategicStochasticProfile([[FixedProfile(v_2) for v_2 in v_1] for v_1 in vals])

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -87,21 +87,18 @@ profile = StrategicProfile([1, 2, 3, 4, 5])
 """
 struct StrategicProfile{T,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
-    function StrategicProfile(vals::Vector{P}) where {T,P<:TimeProfile{T}}
-        if T <: Array
-            throw(
-                ArgumentError(
-                    "It is not possible to use a `Vector{<:Array}` as input " *
-                    "to a `StrategicProfile`.",
-                ),
-            )
-        else
-            new{T,P}(vals)
-        end
-    end
 end
-function StrategicProfile(vals::Vector)
-    return StrategicProfile([FixedProfile(v) for v in vals])
+function StrategicProfile(vals::Vector{T}) where {T}
+    if T <: Array
+        throw(
+            ArgumentError(
+                "It is not possible to use a `Vector{<:Array}` as input " *
+                "to a `StrategicProfile`.",
+            ),
+        )
+    else
+        return StrategicProfile([FixedProfile(v) for v in vals])
+    end
 end
 
 function _value_lookup(::HasStratIndex, sp::StrategicProfile, period)
@@ -138,21 +135,18 @@ profile = ScenarioProfile([1, 2, 3, 4, 5])
 """
 struct ScenarioProfile{T,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
-    function ScenarioProfile(vals::Vector{P}) where {T,P<:TimeProfile{T}}
-        if T <: Array
-            throw(
-                ArgumentError(
-                    "It is not possible to use a `Vector{<:Array}` as input " *
-                    "to a `ScenarioProfile`.",
-                ),
-            )
-        else
-            new{T,P}(vals)
-        end
-    end
 end
-function ScenarioProfile(vals::Vector)
-    return ScenarioProfile([FixedProfile(v) for v in vals])
+function ScenarioProfile(vals::Vector{T}) where {T}
+    if T <: Array
+        throw(
+            ArgumentError(
+                "It is not possible to use a `Vector{<:Array}` as input " *
+                "to a `ScenarioProfile`.",
+            ),
+        )
+    else
+        return ScenarioProfile([FixedProfile(v) for v in vals])
+    end
 end
 
 function _value_lookup(::HasScenarioIndex, sp::ScenarioProfile, period)
@@ -189,21 +183,18 @@ profile = RepresentativeProfile([1, 2, 3, 4, 5])
 """
 struct RepresentativeProfile{T,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
-    function RepresentativeProfile(vals::Vector{P}) where {T,P<:TimeProfile{T}}
-        if T <: Array
-            throw(
-                ArgumentError(
-                    "It is not possible to use a `Vector{<:Array}` as input " *
-                    "to a `RepresentativeProfile`.",
-                ),
-            )
-        else
-            new{T,P}(vals)
-        end
-    end
 end
-function RepresentativeProfile(vals::Vector)
-    return RepresentativeProfile([FixedProfile(v) for v in vals])
+function RepresentativeProfile(vals::Vector{T}) where {T}
+    if T <: Array
+        throw(
+            ArgumentError(
+                "It is not possible to use a `Vector{<:Array}` as input " *
+                "to a `RepresentativeProfile`.",
+            ),
+        )
+    else
+        return RepresentativeProfile([FixedProfile(v) for v in vals])
+    end
 end
 
 function _value_lookup(::HasReprIndex, rp::RepresentativeProfile, period)
@@ -246,23 +237,20 @@ profile = StrategicStochasticProfile([
 """
 struct StrategicStochasticProfile{T,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{<:Vector{P}}
-    function StrategicStochasticProfile(
-        vals::Vector{<:Vector{P}},
-    ) where {T,P<:TimeProfile{T}}
-        if T <: Array
-            throw(
-                ArgumentError(
-                    "It is not possible to use a `Vector{<:Vector{<:Array}}` as input " *
-                    "to a `StrategicStochasticProfile`.",
-                ),
-            )
-        else
-            new{T,P}(vals)
-        end
-    end
 end
-function StrategicStochasticProfile(vals::Vector{<:Vector})
-    return StrategicStochasticProfile([[FixedProfile(v_2) for v_2 in v_1] for v_1 in vals])
+function StrategicStochasticProfile(vals::Vector{<:Vector{T}}) where {T}
+    if T <: Array
+        throw(
+            ArgumentError(
+                "It is not possible to use a `Vector{<:Vector{<:Array}}` as input " *
+                "to a `StrategicStochasticProfile`.",
+            ),
+        )
+    else
+        return StrategicStochasticProfile([
+            [FixedProfile(v_2) for v_2 in v_1] for v_1 in vals
+        ])
+    end
 end
 
 function _value_lookup(::HasStratTreeIndex, ssp::StrategicStochasticProfile, period)

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -1,7 +1,7 @@
 abstract type TimeProfile{T} end
 
 """
-    FixedProfile(val<:Number)
+    FixedProfile(val)
 
 Time profile with a constant value for all time periods.
 
@@ -10,7 +10,7 @@ Time profile with a constant value for all time periods.
 profile = FixedProfile(5)
 ```
 """
-struct FixedProfile{T<:Number} <: TimeProfile{T}
+struct FixedProfile{T} <: TimeProfile{T}
     val::T
 end
 
@@ -19,7 +19,7 @@ function Base.getindex(fp::FixedProfile, _::T) where {T<:Union{TimePeriod,TimeSt
 end
 
 """
-    OperationalProfile(vals::Vector{T}) where {T<:Number}
+    OperationalProfile(vals::Vector{T}) where {T}
 
 Time profile with a value that varies with the operational time period.
 
@@ -30,7 +30,7 @@ If too few values are provided, the last provided value will be repeated.
 profile = OperationalProfile([1, 2, 3, 4, 5])
 ```
 """
-struct OperationalProfile{T<:Number} <: TimeProfile{T}
+struct OperationalProfile{T} <: TimeProfile{T}
     vals::Vector{T}
 end
 
@@ -42,8 +42,8 @@ function Base.getindex(
 end
 
 """
-    StrategicProfile(vals::Vector{P}) where {T<:Number, P<:TimeProfile{T}}
-    StrategicProfile(vals::Vector{<:Number})
+    StrategicProfile(vals::Vector{P}) where {T, P<:TimeProfile{T}}
+    StrategicProfile(vals::Vector)
 
 Time profile with a separate time profile for each strategic period.
 
@@ -57,10 +57,10 @@ profile = StrategicProfile([OperationalProfile([1, 2]), OperationalProfile([3, 4
 profile = StrategicProfile([1, 2, 3, 4, 5])
 ```
 """
-struct StrategicProfile{T<:Number,P<:TimeProfile{T}} <: TimeProfile{T}
+struct StrategicProfile{T,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
 end
-function StrategicProfile(vals::Vector{<:Number})
+function StrategicProfile(vals::Vector)
     return StrategicProfile([FixedProfile(v) for v in vals])
 end
 
@@ -80,8 +80,8 @@ function Base.getindex(
 end
 
 """
-    ScenarioProfile(vals::Vector{P}) where {T<:Number, P<:TimeProfile{T}}
-    ScenarioProfile(vals::Vector{<:Number})
+    ScenarioProfile(vals::Vector{P}) where {T, P<:TimeProfile{T}}
+    ScenarioProfile(vals::Vector)
 
 Time profile with a separate time profile for each scenario.
 
@@ -95,10 +95,10 @@ profile = ScenarioProfile([OperationalProfile([1, 2]), OperationalProfile([3, 4,
 profile = ScenarioProfile([1, 2, 3, 4, 5])
 ```
 """
-struct ScenarioProfile{T<:Number,P<:TimeProfile{T}} <: TimeProfile{T}
+struct ScenarioProfile{T,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
 end
-function ScenarioProfile(vals::Vector{<:Number})
+function ScenarioProfile(vals::Vector)
     return ScenarioProfile([FixedProfile(v) for v in vals])
 end
 
@@ -118,8 +118,8 @@ function Base.getindex(
 end
 
 """
-    RepresentativeProfile(vals::Vector{P}) where {T<:Number, P<:TimeProfile{T}}
-    RepresentativeProfile(vals::Vector{<:Number})
+    RepresentativeProfile(vals::Vector{P}) where {T, P<:TimeProfile{T}}
+    RepresentativeProfile(vals::Vector)
 
 Time profile with a separate time profile for each representative period.
 
@@ -133,10 +133,10 @@ profile = RepresentativeProfile([OperationalProfile([1, 2]), OperationalProfile(
 profile = RepresentativeProfile([1, 2, 3, 4, 5])
 ```
 """
-struct RepresentativeProfile{T<:Number,P<:TimeProfile{T}} <: TimeProfile{T}
+struct RepresentativeProfile{T,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{P}
 end
-function RepresentativeProfile(vals::Vector{<:Number})
+function RepresentativeProfile(vals::Vector)
     return RepresentativeProfile([FixedProfile(v) for v in vals])
 end
 
@@ -158,8 +158,8 @@ function Base.getindex(
 end
 
 """
-    StrategicStochasticProfile(vals::Vector{<:Vector{P}}) where {T<:Number, P<:TimeProfile{T}}
-    StrategicStochasticProfile(vals::Vector{<:Vector{<:Number}})
+    StrategicStochasticProfile(vals::Vector{<:Vector{P}}) where {T, P<:TimeProfile{T}}
+    StrategicStochasticProfile(vals::Vector{<:Vector})
 
 Time profile with a separate time profile for each strategic node in a [`TwoLevelTree`](@ref)
 structure.
@@ -178,10 +178,10 @@ profile = StrategicStochasticProfile([
 ])
 ```
 """
-struct StrategicStochasticProfile{T<:Number,P<:TimeProfile{T}} <: TimeProfile{T}
+struct StrategicStochasticProfile{T,P<:TimeProfile{T}} <: TimeProfile{T}
     vals::Vector{<:Vector{P}}
 end
-function StrategicStochasticProfile(vals::Vector{<:Vector{<:Number}})
+function StrategicStochasticProfile(vals::Vector{<:Vector})
     return StrategicStochasticProfile([[FixedProfile(v_2) for v_2 in v_1] for v_1 in vals])
 end
 
@@ -218,59 +218,59 @@ function Base.getindex(TP::TimeProfile, inds::Any)
 end
 
 import Base: +, -, *, /
-+(a::FixedProfile{T}, b::Number) where {T<:Number} = FixedProfile(a.val + b)
-function +(a::OperationalProfile{T}, b::Number) where {T<:Number}
++(a::FixedProfile{T}, b::Number) where {T} = FixedProfile(a.val + b)
+function +(a::OperationalProfile{T}, b::Number) where {T}
     return OperationalProfile(a.vals .+ b)
 end
-function +(a::StrategicProfile{T}, b::Number) where {T<:Number}
+function +(a::StrategicProfile{T}, b::Number) where {T}
     return StrategicProfile(a.vals .+ b)
 end
-function +(a::ScenarioProfile{T}, b::Number) where {T<:Number}
+function +(a::ScenarioProfile{T}, b::Number) where {T}
     return ScenarioProfile(a.vals .+ b)
 end
-function +(a::RepresentativeProfile{T}, b::Number) where {T<:Number}
+function +(a::RepresentativeProfile{T}, b::Number) where {T}
     return RepresentativeProfile(a.vals .+ b)
 end
-+(a::Number, b::TimeProfile{T}) where {T<:Number} = b + a
--(a::FixedProfile{T}, b::Number) where {T<:Number} = FixedProfile(a.val - b)
-function -(a::OperationalProfile{T}, b::Number) where {T<:Number}
++(a::Number, b::TimeProfile{T}) where {T} = b + a
+-(a::FixedProfile{T}, b::Number) where {T} = FixedProfile(a.val - b)
+function -(a::OperationalProfile{T}, b::Number) where {T}
     return OperationalProfile(a.vals .- b)
 end
-function -(a::StrategicProfile{T}, b::Number) where {T<:Number}
+function -(a::StrategicProfile{T}, b::Number) where {T}
     return StrategicProfile(a.vals .- b)
 end
-function -(a::ScenarioProfile{T}, b::Number) where {T<:Number}
+function -(a::ScenarioProfile{T}, b::Number) where {T}
     return ScenarioProfile(a.vals .- b)
 end
-function -(a::RepresentativeProfile{T}, b::Number) where {T<:Number}
+function -(a::RepresentativeProfile{T}, b::Number) where {T}
     return RepresentativeProfile(a.vals .- b)
 end
 
-*(a::FixedProfile{T}, b::Number) where {T<:Number} = FixedProfile(a.val .* b)
-function *(a::OperationalProfile{T}, b::Number) where {T<:Number}
+*(a::FixedProfile{T}, b::Number) where {T} = FixedProfile(a.val .* b)
+function *(a::OperationalProfile{T}, b::Number) where {T}
     return OperationalProfile(a.vals .* b)
 end
-function *(a::StrategicProfile{T}, b::Number) where {T<:Number}
+function *(a::StrategicProfile{T}, b::Number) where {T}
     return StrategicProfile(a.vals .* b)
 end
-function *(a::ScenarioProfile{T}, b::Number) where {T<:Number}
+function *(a::ScenarioProfile{T}, b::Number) where {T}
     return ScenarioProfile(a.vals .* b)
 end
-function *(a::RepresentativeProfile{T}, b::Number) where {T<:Number}
+function *(a::RepresentativeProfile{T}, b::Number) where {T}
     return RepresentativeProfile(a.vals .* b)
 end
 
-*(a::Number, b::TimeProfile{T}) where {T<:Number} = b * a
-/(a::FixedProfile{T}, b::Number) where {T<:Number} = FixedProfile(a.val / b)
-function /(a::OperationalProfile{T}, b::Number) where {T<:Number}
+*(a::Number, b::TimeProfile{T}) where {T} = b * a
+/(a::FixedProfile{T}, b::Number) where {T} = FixedProfile(a.val / b)
+function /(a::OperationalProfile{T}, b::Number) where {T}
     return OperationalProfile(a.vals ./ b)
 end
-function /(a::StrategicProfile{T}, b::Number) where {T<:Number}
+function /(a::StrategicProfile{T}, b::Number) where {T}
     return StrategicProfile(a.vals ./ b)
 end
-function /(a::ScenarioProfile{T}, b::Number) where {T<:Number}
+function /(a::ScenarioProfile{T}, b::Number) where {T}
     return ScenarioProfile(a.vals ./ b)
 end
-function /(a::RepresentativeProfile{T}, b::Number) where {T<:Number}
+function /(a::RepresentativeProfile{T}, b::Number) where {T}
     return RepresentativeProfile(a.vals ./ b)
 end

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -60,7 +60,7 @@ end
 function Base.getindex(
     op::OperationalProfile,
     i::T,
-) where {T<:Union{TimePeriod,TimeStructure}}
+) where {T<:TimePeriod}
     return op.vals[_oper(i) > length(op.vals) ? end : _oper(i)]
 end
 

--- a/src/representative/rep_periods.jl
+++ b/src/representative/rep_periods.jl
@@ -1,11 +1,11 @@
 """
-    abstract type AbstractRepresentativePeriod{T} <: TimeStructure{T}
+    abstract type AbstractRepresentativePeriod{T} <: TimeStructurePeriod{T}
 
 Abstract type used for time structures that represent a representative period.
 These periods are obtained when iterating through the representative periods of a time
 structure declared by the function [`repr_periods`](@ref).
 """
-abstract type AbstractRepresentativePeriod{T} <: TimeStructure{T} end
+abstract type AbstractRepresentativePeriod{T} <: TimeStructurePeriod{T} end
 
 function _rper(rp::AbstractRepresentativePeriod)
     return error("_rper() not implemented for $(typeof(rp))")

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -3,7 +3,7 @@
 
     SimpleTimes(len::Integer, duration::Vector{T}) where {T}
     SimpleTimes(len::Integer, duration::Number)
-    SimpleTimes(dur::Vector{T}) where {T<:Number}
+    SimpleTimes(dur::Vector{T}) where {T}
 
 A simple time structure consisting of consecutive time periods of varying duration.
 `SimpleTimes` is always the lowest level in a `TimeStruct` time structure. if used.
@@ -34,7 +34,7 @@ end
 function SimpleTimes(len::Integer, duration::Number)
     return SimpleTimes(len, fill(duration, len))
 end
-SimpleTimes(dur::Vector{T}) where {T<:Number} = SimpleTimes(length(dur), dur)
+SimpleTimes(dur::Vector{T}) where {T} = SimpleTimes(length(dur), dur)
 
 _total_duration(st::SimpleTimes) = sum(st.duration)
 
@@ -63,7 +63,7 @@ end
 Time period for a single operational period. It is created through iterating through a
 [`SimpleTimes`](@ref) time structure.
 """
-struct SimplePeriod{T<:Number} <: TimePeriod
+struct SimplePeriod{T} <: TimePeriod
     op::Int
     duration::T
 end

--- a/src/simple.jl
+++ b/src/simple.jl
@@ -1,9 +1,9 @@
 """
     struct SimpleTimes{T} <: TimeStructure{T}
 
-    SimpleTimes(len::Integer, duration::Vector{T}) where {T}
-    SimpleTimes(len::Integer, duration::Number)
-    SimpleTimes(dur::Vector{T}) where {T}
+    SimpleTimes(len::Integer, duration::Vector{T}) where {T<:Duration}
+    SimpleTimes(len::Integer, duration::Duration)
+    SimpleTimes(dur::Vector{T}) where {T<:Duration}
 
 A simple time structure consisting of consecutive time periods of varying duration.
 `SimpleTimes` is always the lowest level in a `TimeStruct` time structure. if used.
@@ -19,7 +19,7 @@ varying = SimpleTimes([2, 2, 2, 4, 10]) # 5 periods of varying length
 struct SimpleTimes{T} <: TimeStructure{T}
     len::Int
     duration::Vector{T}
-    function SimpleTimes(len::Integer, duration::Vector{T}) where {T}
+    function SimpleTimes(len::Integer, duration::Vector{T}) where {T<:Duration}
         if len > length(duration)
             throw(
                 ArgumentError(
@@ -31,10 +31,10 @@ struct SimpleTimes{T} <: TimeStructure{T}
         end
     end
 end
-function SimpleTimes(len::Integer, duration::Number)
+function SimpleTimes(len::Integer, duration::Duration)
     return SimpleTimes(len, fill(duration, len))
 end
-SimpleTimes(dur::Vector{T}) where {T} = SimpleTimes(length(dur), dur)
+SimpleTimes(dur::Vector{T}) where {T<:Duration} = SimpleTimes(length(dur), dur)
 
 _total_duration(st::SimpleTimes) = sum(st.duration)
 
@@ -63,7 +63,7 @@ end
 Time period for a single operational period. It is created through iterating through a
 [`SimpleTimes`](@ref) time structure.
 """
-struct SimplePeriod{T} <: TimePeriod
+struct SimplePeriod{T<:Number} <: TimePeriod
     op::Int
     duration::T
 end

--- a/src/strategic/strat_periods.jl
+++ b/src/strategic/strat_periods.jl
@@ -1,11 +1,11 @@
 """
-    abstract type AbstractStrategicPeriod{S,T} <: TimeStructure{T}
+    abstract type AbstractStrategicPeriod{S,T} <: TimeStructurePeriod{T}
 
 Abstract type used for time structures that represent a strategic period.
 These periods are obtained when iterating through the strategic periods of a time
 structure declared by the function [`strat_periods`](@ref).
 """
-abstract type AbstractStrategicPeriod{S,T} <: TimeStructure{T} end
+abstract type AbstractStrategicPeriod{S,T} <: TimeStructurePeriod{T} end
 
 function _strat_per(sp::AbstractStrategicPeriod)
     return error("_strat_per() not implemented for $(typeof(sp))")

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -4,11 +4,23 @@ Duration = Number
 """
     abstract type TimeStructure{T<:Duration}
 
-Abstract type representing different time structures that
-consists of one or more time periods. The type 'T' gives
-the data type used for the duration of the time periods.
+Abstract type representing different time structures that consists of one or more time
+periods.
+
+The type 'T' gives the data type used for the duration of the time periods.
 """
 abstract type TimeStructure{T<:Duration} end
+
+"""
+    abstract type TimeStructurePeriod{T} <: TimeStructure{T}
+
+Abstract type representing different time structures that consists of one or more time
+periods. It is used for `TimeStructure`s that can also act as index for periods, *e.g.*,
+[`AbstractStrategicPeriod`](@ref).
+
+The type 'T' gives the data type used for the duration of the time periods.
+"""
+abstract type TimeStructurePeriod{T} <: TimeStructure{T} end
 
 """
     abstract type TimeStructInnerIter{T<:Duration}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1036,15 +1036,19 @@ end
     @test length(sps) == 5
 end
 
-# @testitem "Profiles constructors" begin
-#     # Checking the input type
-#     @test_throws MethodError FixedProfile("wrong_input")
-#     @test_throws MethodError OperationalProfile("wrong_input")
-#     @test_throws MethodError ScenarioProfile("wrong_input")
-#     @test_throws MethodError RepresentativeProfile("wrong_input")
-#     @test_throws MethodError StrategicProfile("wrong_input")
-#     @test_throws MethodError StrategicProfile("StrategicStochasticProfile")
-# end
+@testitem "Profiles constructors" begin
+    # Checking the input type
+    @test_throws ArgumentError FixedProfile(["wrong_input"])
+    @test_throws ArgumentError OperationalProfile([["wrong_input"]])
+    @test_throws ArgumentError ScenarioProfile([OperationalProfile([["wrong_input"]])])
+    @test_throws ArgumentError RepresentativeProfile([
+        OperationalProfile([["wrong_input"]]),
+    ])
+    @test_throws ArgumentError StrategicProfile([OperationalProfile([["wrong_input"]])])
+    @test_throws ArgumentError StrategicStochasticProfile([[[
+        OperationalProfile([["wrong_input"]]),
+    ]]])
+end
 
 @testitem "Profiles and strategic periods" begin
     profile = StrategicProfile([1, 2, 3])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -750,6 +750,7 @@ end
     fp = FixedProfile(12)
     @test fp[first(day)] == 12
     @test sum(fp[t] for t in day) == 12 * 24
+    @test sum(fp[day]) == 12 * 24
     fpadd = fp + 4
     @test sum(fpadd[t] for t in day) == 16 * 24
     fpsub = fp - 3
@@ -770,6 +771,7 @@ end
 
     op = OperationalProfile([2, 2, 2, 2, 1])
     @test sum(op[t] for t in day) == 4 * 2 + 20 * 1
+    @test sum(op[day]) == 4 * 2 + 20 * 1
     @test op[TimeStruct.SimplePeriod(7, 1)] == 1
     opunit = OperationalProfile([2, 3, 4], u"m/s")
     @test opunit[TimeStruct.SimplePeriod(6, 1)] == 4u"m/s"
@@ -790,13 +792,18 @@ end
     @test sum(fp[t_inv] == 12 for t_inv in strat_periods(day)) == 1
 
     ts = TwoLevel(5, 168, SimpleTimes(7, 24))
+    spers = strat_periods(ts)
     p1 = first(ts)
     @test sum(fp[t] for t in ts) == 12.0 * length(ts)
 
     sp1 = StrategicProfile([fp])
     @test sum(sp1[t] for t in ts) == 12.0 * length(ts)
+    @test sum(sp1[ts]) == 12.0 * length(ts)
+    @test sum(sp1[spers]) == 12.0 * length(spers)
     sp2 = StrategicProfile([op, op, fp])
     @test sum(sp2[t] for t in ts) == 2 * 11 + 3 * 84
+    @test sum(sp2[ts]) == 2 * 11 + 3 * 84
+    @test_throws ErrorException sp2[spers[1]]
     spadd = 1 + sp2
     @test spadd[p1] == 3
     spmin = sp2 - 3
@@ -815,10 +822,16 @@ end
     @test_throws ErrorException sp1["dummy"]
 
     tsc = TwoLevel(3, 168, OperationalScenarios(3, SimpleTimes(7, 24)))
+    spers = strat_periods(tsc)
+    opscens = opscenarios(tsc)
     @test sum(fp[t] for t in tsc) == 12.0 * length(tsc)
+    @test sum(fp[tsc]) == 12.0 * length(tsc)
+    @test sum(fp[opscens]) == 12.0 * length(opscens)
     scp = ScenarioProfile([op, 2 * op, 3 * op])
     @test sum(scp[t] for t in tsc) == 3 * (11 + 2 * 11 + 3 * 11)
-
+    @test sum(scp[tsc]) == 3 * (11 + 2 * 11 + 3 * 11)
+    @test_throws ErrorException scp[spers[1]]
+    @test_throws ErrorException scp[opscens[1]]
     @test_throws ErrorException scp["dummy"]
 
     scp2 = ScenarioProfile([
@@ -827,6 +840,7 @@ end
         OperationalProfile([4, 5]),
     ])
     @test sum(scp2[t] for t in tsc) == 201
+    @test sum(scp2[tsc]) == 201
 
     ssp = StrategicProfile([scp, scp2])
     @test sum(ssp[t] for t in tsc) == 200

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1022,15 +1022,15 @@ end
     @test length(sps) == 5
 end
 
-@testitem "Profiles constructors" begin
-    # Checking the input type
-    @test_throws MethodError FixedProfile("wrong_input")
-    @test_throws MethodError OperationalProfile("wrong_input")
-    @test_throws MethodError ScenarioProfile("wrong_input")
-    @test_throws MethodError RepresentativeProfile("wrong_input")
-    @test_throws MethodError StrategicProfile("wrong_input")
-    @test_throws MethodError StrategicProfile("StrategicStochasticProfile")
-end
+# @testitem "Profiles constructors" begin
+#     # Checking the input type
+#     @test_throws MethodError FixedProfile("wrong_input")
+#     @test_throws MethodError OperationalProfile("wrong_input")
+#     @test_throws MethodError ScenarioProfile("wrong_input")
+#     @test_throws MethodError RepresentativeProfile("wrong_input")
+#     @test_throws MethodError StrategicProfile("wrong_input")
+#     @test_throws MethodError StrategicProfile("StrategicStochasticProfile")
+# end
 
 @testitem "Profiles and strategic periods" begin
     profile = StrategicProfile([1, 2, 3])


### PR DESCRIPTION
I tried running an EMX model with ParametricOptInterface, but TimeStruct requires profiles to be `T<:Number`, and this is not the case for the `MOI.Parameter` or variables. This PR relaxes contraint on T for profiles to be T<:Number to support ParametricOptInterface. We may consider keeping the type constraints on the Base functions, perhaps, but this PR removes them all.