### PR TITLE
Change in the type structure

### DIFF
--- a/docs/src/reference/internal.md
+++ b/docs/src/reference/internal.md
@@ -39,7 +39,7 @@ TimeStruct.StrategicPeriod
 
 ```@docs
 TimeStruct.SingleStrategicPeriodWrapper
-TimeStruct.StratPeriods
+TimeStruct.StratPers
 ```
 
 ## Representative period types
@@ -58,9 +58,9 @@ TimeStruct.StratNodeReprPeriod
 
 ```@docs
 TimeStruct.SingleReprPeriodWrapper
-TimeStruct.ReprPeriods
-TimeStruct.StratReprPeriods
-TimeStruct.StratNodeReprPeriods
+TimeStruct.ReprPers
+TimeStruct.StratReprPers
+TimeStruct.StratNodeReprPers
 ```
 
 ## Operational scenarios types
@@ -71,10 +71,10 @@ TimeStruct.StratNodeReprPeriods
 TimeStruct.AbstractOperationalScenario
 TimeStruct.SingleScenario
 TimeStruct.OperationalScenario
-TimeStruct.ReprOperationalScenario
-TimeStruct.StratOperationalScenario
-TimeStruct.StratReprOpscenario
-TimeStruct.StratNodeOperationalScenario
+TimeStruct.ReprOpScenario
+TimeStruct.StratOpScenario
+TimeStruct.StratReprOpScenario
+TimeStruct.StratNodeOpScenario
 TimeStruct.StratNodeReprOpScenario
 ```
 
@@ -85,7 +85,7 @@ TimeStruct.SingleScenarioWrapper
 TimeStruct.OpScens
 TimeStruct.RepOpScens
 TimeStruct.StratOpScens
-TimeStruct.StratReprOpscenarios
+TimeStruct.StratReprOpScens
 TimeStruct.StratNodeOpScens
 TimeStruct.StratNodeReprOpScens
 ```

--- a/docs/src/reference/internal.md
+++ b/docs/src/reference/internal.md
@@ -1,5 +1,12 @@
 # Internal types
 
+## Internal supertypes
+
+```@docs
+TimeStruct.TimeStructInnerIter
+TimeStruct.TimeStructOuterIter
+```
+
 ## Strategic period types ([`TwoLevelTree`](@ref))
 
 ### Single types

--- a/src/calendar.jl
+++ b/src/calendar.jl
@@ -90,7 +90,7 @@ function Base.last(ts::CalendarTimes)
 end
 
 """
-    struct CalendarPeriod <: TimePeriod
+    struct CalendarPeriod{T} <: TimePeriod
 
 Time period for a single operational period. It is created through iterating through a
 [`CalendarTimes`](@ref) time structure with duration measured in hours (by default).

--- a/src/op_scenarios/core_types.jl
+++ b/src/op_scenarios/core_types.jl
@@ -108,7 +108,7 @@ function Base.last(oscs::OperationalScenarios)
 end
 
 """
-	ScenarioPeriod{P} <: TimePeriod where {P<:TimePeriod}
+	struct ScenarioPeriod{P} <: TimePeriod where {P<:TimePeriod}
 
 Time period for a single operational period. It is created through iterating through a
 [`OperationalScenarios`](@ref) time structure. It is as well created as period within

--- a/src/op_scenarios/core_types.jl
+++ b/src/op_scenarios/core_types.jl
@@ -128,7 +128,8 @@ probability(t::ScenarioPeriod) = t.prob
 
 Base.show(io::IO, t::ScenarioPeriod) = print(io, "sc$(_opscen(t))-$(_period(t))")
 function Base.isless(t1::ScenarioPeriod, t2::ScenarioPeriod)
-    return _opscen(t1) < _opscen(t2) || (_opscen(t1) == _opscen(t2) && _period(t1) < _period(t2))
+    return _opscen(t1) < _opscen(t2) ||
+           (_opscen(t1) == _opscen(t2) && _period(t1) < _period(t2))
 end
 
 # Convenience constructors for the type

--- a/src/op_scenarios/core_types.jl
+++ b/src/op_scenarios/core_types.jl
@@ -99,12 +99,8 @@ function Base.iterate(oscs::OperationalScenarios, state = (nothing, 1))
     return ScenarioPeriod(oscs, next[1], osc), (next[2], osc)
 end
 function Base.last(oscs::OperationalScenarios)
-    return ScenarioPeriod(
-        oscs.len,
-        oscs.probability[oscs.len],
-        _multiple_adj(oscs, oscs.len),
-        last(oscs.scenarios[oscs.len]),
-    )
+    per = last(oscs.scenarios[oscs.len])
+    return ScenarioPeriod(oscs, per, oscs.len)
 end
 
 """
@@ -116,9 +112,9 @@ Time period for a single operational period. It is created through iterating thr
 """
 struct ScenarioPeriod{P} <: TimePeriod where {P<:TimePeriod}
     osc::Int
-    prob::Float64
-    multiple::Float64
     period::P
+    multiple::Float64
+    prob::Float64
 end
 _period(t::ScenarioPeriod) = t.period
 
@@ -139,13 +135,13 @@ end
 function ScenarioPeriod(osc::Int, prob::Number, multiple::Number, period)
     return ScenarioPeriod(
         osc,
-        Base.convert(Float64, prob),
-        Base.convert(Float64, multiple),
         period,
+        Base.convert(Float64, multiple),
+        Base.convert(Float64, prob),
     )
 end
 function ScenarioPeriod(oscs::OperationalScenarios, per::TimePeriod, osc::Int)
     prob = oscs.probability[osc]
     mult = _multiple_adj(oscs, osc)
-    return ScenarioPeriod(osc, prob, mult, per)
+    return ScenarioPeriod(osc, per, mult, prob)
 end

--- a/src/op_scenarios/core_types.jl
+++ b/src/op_scenarios/core_types.jl
@@ -120,18 +120,19 @@ struct ScenarioPeriod{P} <: TimePeriod where {P<:TimePeriod}
     multiple::Float64
     period::P
 end
+_period(t::ScenarioPeriod) = t.period
 
-_oper(t::ScenarioPeriod) = _oper(t.period)
+_oper(t::ScenarioPeriod) = _oper(_period(t))
 _opscen(t::ScenarioPeriod) = t.osc
 
-isfirst(t::ScenarioPeriod) = isfirst(t.period)
-duration(t::ScenarioPeriod) = duration(t.period)
+isfirst(t::ScenarioPeriod) = isfirst(_period(t))
+duration(t::ScenarioPeriod) = duration(_period(t))
 multiple(t::ScenarioPeriod) = t.multiple
 probability(t::ScenarioPeriod) = t.prob
 
-Base.show(io::IO, t::ScenarioPeriod) = print(io, "sc$(t.osc)-$(t.period)")
+Base.show(io::IO, t::ScenarioPeriod) = print(io, "sc$(_opscen(t))-$(_period(t))")
 function Base.isless(t1::ScenarioPeriod, t2::ScenarioPeriod)
-    return t1.osc < t2.osc || (t1.osc == t2.osc && t1.period < t2.period)
+    return _opscen(t1) < _opscen(t2) || (_opscen(t1) == _opscen(t2) && _period(t1) < _period(t2))
 end
 
 # Convenience constructors for the type

--- a/src/op_scenarios/opscenarios.jl
+++ b/src/op_scenarios/opscenarios.jl
@@ -110,7 +110,7 @@ time periods. It is created when iterating through [`OpScens`](@ref).
 """
 struct OperationalScenario{T,OP<:TimeStructure{T}} <: AbstractOperationalScenario{T}
     scen::Int
-    mult_sc::Float64
+    mult_scen::Float64
     probability::Float64
     operational::OP
 end
@@ -118,17 +118,17 @@ end
 _opscen(osc::OperationalScenario) = osc.scen
 
 probability(osc::OperationalScenario) = osc.probability
-mult_scen(osc::OperationalScenario) = osc.mult_sc
+mult_scen(osc::OperationalScenario) = osc.mult_scen
 
 Base.show(io::IO, osc::OperationalScenario) = print(io, "sc-$(osc.scen)")
 
 # Provide a constructor to simplify the design
 function ScenarioPeriod(
     osc::OperationalScenario,
-    per::P,
-) where {P<:Union{TimePeriod,TimeStructure}}
+    per::TimePeriod,
+)
     mult = mult_scen(osc) * multiple(per)
-    return ScenarioPeriod(_opscen(osc), probability(osc), mult, per)
+    return ScenarioPeriod(_opscen(osc), per, mult, probability(osc))
 end
 
 # Add basic functions of iterators

--- a/src/op_scenarios/opscenarios.jl
+++ b/src/op_scenarios/opscenarios.jl
@@ -123,10 +123,7 @@ mult_scen(osc::OperationalScenario) = osc.mult_scen
 Base.show(io::IO, osc::OperationalScenario) = print(io, "sc-$(osc.scen)")
 
 # Provide a constructor to simplify the design
-function ScenarioPeriod(
-    osc::OperationalScenario,
-    per::TimePeriod,
-)
+function ScenarioPeriod(osc::OperationalScenario, per::TimePeriod)
     mult = mult_scen(osc) * multiple(per)
     return ScenarioPeriod(_opscen(osc), per, mult, probability(osc))
 end

--- a/src/op_scenarios/opscenarios.jl
+++ b/src/op_scenarios/opscenarios.jl
@@ -1,5 +1,5 @@
 """
-    AbstractOperationalScenario{T} <: TimeStructure{T}
+    abstract type AbstractOperationalScenario{T} <: TimeStructure{T}
 
 Abstract type used for time structures that represent an operational scenario.
 These periods are obtained when iterating through the operational scenarios of a time
@@ -26,7 +26,7 @@ ScenarioIndexable(::Type{<:AbstractOperationalScenario}) = HasScenarioIndex()
 ScenarioIndexable(::Type{<:TimePeriod}) = HasScenarioIndex()
 
 """
-    SingleScenario{T,SC<:TimeStructure{T}} <: AbstractRepresentativePeriod{T}
+    struct SingleScenario{T,SC<:TimeStructure{T}} <: AbstractRepresentativePeriod{T}
 
 A type representing a single operational scenario supporting iteration over its
 time periods. It is created when iterating through [`SingleScenarioWrapper`](@ref).
@@ -68,15 +68,17 @@ function Base.last( # TODO: Considering removing the function as the the structu
 end
 
 """
-    SingleScenarioWrapper{T,OP<:TimeStructure{T}} <: TimeStructure{T}
+    struct SingleScenarioWrapper{T,OP<:TimeStructure{T}} <: TimeStructInnerIter{T}
 
 Type for iterating through the individual operational scenarios of a time structure
 without [`OperationalScenarios`](@ref). It is automatically created through the function
 [`opscenarios`](@ref).
 """
-struct SingleScenarioWrapper{T,SC<:TimeStructure{T}} <: TimeStructure{T}
+struct SingleScenarioWrapper{T,SC<:TimeStructure{T}} <: TimeStructInnerIter{T}
     ts::SC
 end
+
+_oper_struct(oscs::SingleScenarioWrapper) = oscs.ts
 
 """
     opscenarios(ts::TimeStructure)
@@ -91,17 +93,17 @@ When the `TimeStructure` is a `TimeStructure`, `opscenarios` returns a
 opscenarios(ts::TimeStructure) = SingleScenarioWrapper(ts)
 
 # Add basic functions of iterators
-Base.length(ssw::SingleScenarioWrapper) = 1
+Base.length(oscs::SingleScenarioWrapper) = 1
 function Base.eltype(::Type{SingleScenarioWrapper{T,SC}}) where {T,SC}
     return SingleScenario{T,SC}
 end
-function Base.iterate(ssw::SingleScenarioWrapper, state = nothing)
+function Base.iterate(oscs::SingleScenarioWrapper, state = nothing)
     !isnothing(state) && return nothing
-    return SingleScenario(ssw.ts), 1
+    return SingleScenario(_oper_struct(oscs)), 1
 end
 
 """
-    OperationalScenario{T,OP<:TimeStructure{T}} <: AbstractOperationalScenario{T}
+    struct OperationalScenario{T,OP<:TimeStructure{T}} <: AbstractOperationalScenario{T}
 
 A type representing a single operational scenario supporting iteration over its
 time periods. It is created when iterating through [`OpScens`](@ref).
@@ -151,17 +153,17 @@ function Base.eachindex(osc::OperationalScenario)
 end
 
 """
-    OpScens{T,OP}
+    struct OpScens{T,OP} <: TimeStructInnerIter{T}
 
 Type for iterating through the individual operational scenarios of a
 [`OperationalScenarios`](@ref) time structure. It is automatically created through the
 function [`opscenarios`](@ref).
 """
-struct OpScens{T,OP}
+struct OpScens{T,OP} <: TimeStructInnerIter{T}
     ts::OperationalScenarios{T,OP}
 end
 
-_oper_it(oscs::OpScens) = oscs.ts
+_oper_struct(oscs::OpScens) = oscs.ts
 
 """
 When the `TimeStructure` is an [`OperationalScenarios`](@ref), `opscenarios` returns the
@@ -173,14 +175,14 @@ opscenarios(oscs::OperationalScenarios) = OpScens(oscs)
 function OperationalScenario(oscs::OpScens, per::Int)
     return OperationalScenario(
         per,
-        _multiple_adj(oscs.ts, per),
-        oscs.ts.probability[per],
-        oscs.ts.scenarios[per],
+        _multiple_adj(_oper_struct(oscs), per),
+        _oper_struct(oscs).probability[per],
+        _oper_struct(oscs).scenarios[per],
     )
 end
 
 # Add basic functions of iterators
-Base.length(oscs::OpScens) = oscs.ts.len
+Base.length(oscs::OpScens) = _oper_struct(oscs).len
 function Base.eltype(_::Type{OpScens{T,OP}}) where {T,OP<:TimeStructure{T}}
     return OperationalScenario{T,OP}
 end
@@ -194,6 +196,6 @@ function Base.getindex(oscs::OpScens, index::Int)
     return OperationalScenario(oscs, index)
 end
 function Base.eachindex(oscs::OpScens)
-    return eachindex(oscs.ts.scenarios)
+    return eachindex(_oper_struct(oscs).scenarios)
 end
 Base.last(oscs::OpScens) = OperationalScenario(oscs, length(oscs))

--- a/src/op_scenarios/rep_periods.jl
+++ b/src/op_scenarios/rep_periods.jl
@@ -100,7 +100,9 @@ function Base.eltype(_::Type{RepOpScens{SC}}) where {T,OP,SC<:OpScens{T,OP}}
     return ReprOpScenario{T,eltype(SC)}
 end
 function Base.iterate(oscs::RepOpScens, state = (nothing, 1))
-    next = isnothing(state[1]) ? iterate(_oper_struct(oscs)) : iterate(_oper_struct(oscs), state[1])
+    next =
+        isnothing(state[1]) ? iterate(_oper_struct(oscs)) :
+        iterate(_oper_struct(oscs), state[1])
     isnothing(next) && return nothing
 
     scen = state[2]

--- a/src/op_scenarios/rep_periods.jl
+++ b/src/op_scenarios/rep_periods.jl
@@ -72,7 +72,7 @@ _rper(oscs::RepOpScens) = oscs.rp
 
 mult_repr(oscs::RepOpScens) = oscs.mult_rp
 
-_oper_it(oscs::RepOpScens) = oscs.opscens
+_oper_struct(oscs::RepOpScens) = oscs.opscens
 
 """
 When the `TimeStructure` is a [`RepresentativePeriod`](@ref) with [`OperationalScenarios`](@ref),
@@ -88,33 +88,33 @@ function ReprOperationalScenario(oscs::RepOpScens, scen::Int, per)
         _rper(oscs),
         scen,
         mult_repr(oscs),
-        _multiple_adj(_oper_it(_oper_it(oscs)), scen),
+        _multiple_adj(_oper_struct(_oper_struct(oscs)), scen),
         probability(per),
         per,
     )
 end
 
 # Add basic functions of iterators
-Base.length(oscs::RepOpScens) = length(_oper_it(_oper_it(oscs)).scenarios)
+Base.length(oscs::RepOpScens) = length(_oper_struct(_oper_struct(oscs)).scenarios)
 function Base.eltype(_::Type{RepOpScens{SC}}) where {T,OP,SC<:OpScens{T,OP}}
     return ReprOperationalScenario{T,eltype(SC)}
 end
 function Base.iterate(oscs::RepOpScens, state = (nothing, 1))
-    next = isnothing(state[1]) ? iterate(_oper_it(oscs)) : iterate(_oper_it(oscs), state[1])
+    next = isnothing(state[1]) ? iterate(_oper_struct(oscs)) : iterate(_oper_struct(oscs), state[1])
     isnothing(next) && return nothing
 
     scen = state[2]
     return ReprOperationalScenario(oscs, _opscen(next[1]), next[1]), (next[2], scen + 1)
 end
 function Base.getindex(oscs::RepOpScens, index::Int)
-    per = _oper_it(oscs)[index]
+    per = _oper_struct(oscs)[index]
     return ReprOperationalScenario(oscs, _opscen(per), per)
 end
 function Base.eachindex(oscs::RepOpScens)
-    return eachindex(_oper_it(oscs))
+    return eachindex(_oper_struct(oscs))
 end
 function Base.last(oscs::RepOpScens)
-    per = last(_oper_it(oscs))
+    per = last(_oper_struct(oscs))
     return ReprOperationalScenario(oscs, _opscen(per), per)
 end
 

--- a/src/op_scenarios/rep_periods.jl
+++ b/src/op_scenarios/rep_periods.jl
@@ -1,5 +1,5 @@
 """
-    ReprOpScenario{T,OP<:TimeStructure{T}} <: AbstractOperationalScenario{T}
+    struct ReprOpScenario{T,OP<:TimeStructure{T}} <: AbstractOperationalScenario{T}
 
 A type representing a single operational scenarios supporting iteration over its
 time periods. It is created when iterating through [`RepOpScens`](@ref).
@@ -56,13 +56,13 @@ function Base.last(osc::ReprOpScenario)
 end
 
 """
-    RepOpScens{OP}
+    struct RepOpScens{T,OP<:TimeStructInnerIter{T}} <: TimeStructOuterIter{T}
 
 Type for iterating through the individual operational scenarios of a
 [`RepresentativePeriod`](@ref) time structure. It is automatically created through the
 function [`opscenarios`](@ref).
 """
-struct RepOpScens{OP}
+struct RepOpScens{T,OP<:TimeStructInnerIter{T}} <: TimeStructOuterIter{T}
     rp::Int
     mult_rp::Float64
     opscens::OP

--- a/src/op_scenarios/strat_periods.jl
+++ b/src/op_scenarios/strat_periods.jl
@@ -97,7 +97,9 @@ end
 # Add basic functions of iterators
 Base.length(oscs::StratOpScens) = length(_oper_struct(oscs))
 function Base.iterate(oscs::StratOpScens, state = (nothing, 1))
-    next = isnothing(state[1]) ? iterate(_oper_struct(oscs)) : iterate(_oper_struct(oscs), state[1])
+    next =
+        isnothing(state[1]) ? iterate(_oper_struct(oscs)) :
+        iterate(_oper_struct(oscs), state[1])
     isnothing(next) && return nothing
 
     scen = state[2]
@@ -247,7 +249,9 @@ function Base.eltype(_::Type{StratReprOpScens{SC}}) where {T,OP,SC<:OpScens{T,OP
     return StratReprOpScenario{T,eltype(SC)}
 end
 function Base.iterate(oscs::StratReprOpScens, state = (nothing, 1))
-    next = isnothing(state[1]) ? iterate(_oper_struct(oscs)) : iterate(_oper_struct(oscs), state[1])
+    next =
+        isnothing(state[1]) ? iterate(_oper_struct(oscs)) :
+        iterate(_oper_struct(oscs), state[1])
     isnothing(next) && return nothing
 
     return StratReprOpScenario(oscs, state[2], next[1]), (next[2], state[2] + 1)

--- a/src/op_scenarios/strat_periods.jl
+++ b/src/op_scenarios/strat_periods.jl
@@ -1,5 +1,5 @@
 """
-    StratOperationalScenario{T,OP<:TimeStructure{T}} <: AbstractOperationalScenario{T}
+    struct StratOperationalScenario{T,OP<:TimeStructure{T}} <: AbstractOperationalScenario{T}
 
 A type representing a single operational scenario supporting iteration over its
 time periods. It is created when iterating through [`StratOpScens`](@ref).
@@ -57,13 +57,13 @@ function Base.last(osc::StratOperationalScenario)
 end
 
 """
-    StratOpScens{OP}
+    struct StratOpScens{T,OP<:TimeStructInnerIter{T}} <: TimeStructOuterIter{T}
 
 Type for iterating through the individual operational scenarios of a
 [`StrategicPeriod`](@ref) time structure. It is automatically created through the function
 [`opscenarios`](@ref).
 """
-struct StratOpScens{OP}
+struct StratOpScens{T,OP<:TimeStructInnerIter{T}} <: TimeStructOuterIter{T}
     sp::Int
     mult_sp::Float64
     opscens::OP
@@ -73,7 +73,7 @@ _strat_per(oscs::StratOpScens) = oscs.sp
 
 mult_strat(oscs::StratOpScens) = oscs.mult_sp
 
-_oper_it(oscs::StratOpScens) = oscs.opscens
+_oper_struct(oscs::StratOpScens) = oscs.opscens
 
 """
 When the `TimeStructure` is a [`StrategicPeriod`](@ref), `opscenarios` returns the iterator
@@ -95,20 +95,20 @@ function StratOperationalScenario(oscs::StratOpScens, scen::Int, per)
 end
 
 # Add basic functions of iterators
-Base.length(oscs::StratOpScens) = length(_oper_it(oscs))
+Base.length(oscs::StratOpScens) = length(_oper_struct(oscs))
 function Base.iterate(oscs::StratOpScens, state = (nothing, 1))
-    next = isnothing(state[1]) ? iterate(_oper_it(oscs)) : iterate(_oper_it(oscs), state[1])
+    next = isnothing(state[1]) ? iterate(_oper_struct(oscs)) : iterate(_oper_struct(oscs), state[1])
     isnothing(next) && return nothing
 
     scen = state[2]
     return StratOperationalScenario(oscs, _opscen(next[1]), next[1]), (next[2], scen + 1)
 end
 function Base.getindex(oscs::StratOpScens, index::Int)
-    per = _oper_it(oscs)[index]
+    per = _oper_struct(oscs)[index]
     return StratOperationalScenario(oscs, index, per)
 end
 function Base.eachindex(oscs::StratOpScens)
-    return eachindex(_oper_it(oscs))
+    return eachindex(_oper_struct(oscs))
 end
 function Base.last(oscs::StratOpScens)
     per = last(oscs.repr)
@@ -116,7 +116,7 @@ function Base.last(oscs::StratOpScens)
 end
 
 """
-    StratReprOpscenario{T, OP<:TimeStructure{T}} <: AbstractRepresentativePeriod{T}
+    struct StratReprOpscenario{T, OP<:TimeStructure{T}} <: AbstractRepresentativePeriod{T}
 
 A type representing a single representative period supporting iteration over its
 time periods. It is created when iterating through [`StratReprPeriods`](@ref).
@@ -181,13 +181,13 @@ function Base.last(osc::StratReprOpscenario)
 end
 
 """
-    StratReprOpscenarios{OP}
+    struct StratReprOpscenarios{T,OP<:TimeStructInnerIter{T}} <: TimeStructOuterIter{T}
 
 Type for iterating through the individual operational scenarios of a
 [`StrategicPeriod`](@ref) time structure with [`RepresentativePeriods`](@ref). It is
 automatically created through the function [`opscenarios`](@ref).
 """
-struct StratReprOpscenarios{OP}
+struct StratReprOpscenarios{T,OP<:TimeStructInnerIter{T}} <: TimeStructOuterIter{T}
     sp::Int
     rp::Int
     mult_sp::Float64
@@ -201,7 +201,7 @@ _rper(oscs::StratReprOpscenarios) = oscs.rp
 mult_strat(oscs::StratReprOpscenarios) = oscs.mult_sp
 mult_repr(oscs::StratReprOpscenarios) = oscs.mult_rp
 
-_oper_it(oscs::StratReprOpscenarios) = oscs.opscens
+_oper_struct(oscs::StratReprOpscenarios) = oscs.opscens
 
 function opscenarios(rp::StratReprPeriod{T,RepresentativePeriod{T,OP}}) where {T,OP}
     return StratReprOpscenarios(
@@ -240,25 +240,25 @@ function StratReprOpscenario(oscs::StratReprOpscenarios, scen, per)
 end
 
 # Add basic functions of iterators
-Base.length(oscs::StratReprOpscenarios) = length(_oper_it(oscs))
+Base.length(oscs::StratReprOpscenarios) = length(_oper_struct(oscs))
 function Base.eltype(_::Type{StratReprOpscenarios{SC}}) where {T,OP,SC<:OpScens{T,OP}}
     return StratReprOpscenario{T,eltype(SC)}
 end
 function Base.iterate(oscs::StratReprOpscenarios, state = (nothing, 1))
-    next = isnothing(state[1]) ? iterate(_oper_it(oscs)) : iterate(_oper_it(oscs), state[1])
+    next = isnothing(state[1]) ? iterate(_oper_struct(oscs)) : iterate(_oper_struct(oscs), state[1])
     isnothing(next) && return nothing
 
     return StratReprOpscenario(oscs, state[2], next[1]), (next[2], state[2] + 1)
 end
 function Base.getindex(oscs::StratReprOpscenarios, index::Int)
-    per = _oper_it(oscs)[index]
+    per = _oper_struct(oscs)[index]
     return StratReprOpscenario(oscs, _opscen(per), per)
 end
 function Base.eachindex(oscs::StratReprOpscenarios)
-    return eachindex(_oper_it(oscs))
+    return eachindex(_oper_struct(oscs))
 end
 function Base.last(oscs::StratReprOpscenarios)
-    per = last(_oper_it(oscs))
+    per = last(_oper_struct(oscs))
     return StratReprOpscenario(oscs, _opscen(per), per)
 end
 

--- a/src/op_scenarios/strat_periods.jl
+++ b/src/op_scenarios/strat_periods.jl
@@ -1,10 +1,10 @@
 """
-    struct StratOperationalScenario{T,OP<:TimeStructure{T}} <: AbstractOperationalScenario{T}
+    struct StratOpScenario{T,OP<:TimeStructure{T}} <: AbstractOperationalScenario{T}
 
 A type representing a single operational scenario supporting iteration over its
 time periods. It is created when iterating through [`StratOpScens`](@ref).
 """
-struct StratOperationalScenario{T,OP<:TimeStructure{T}} <: AbstractOperationalScenario{T}
+struct StratOpScenario{T,OP<:TimeStructure{T}} <: AbstractOperationalScenario{T}
     sp::Int
     scen::Int
     mult_sp::Float64
@@ -13,45 +13,45 @@ struct StratOperationalScenario{T,OP<:TimeStructure{T}} <: AbstractOperationalSc
     operational::OP
 end
 
-_strat_per(osc::StratOperationalScenario) = osc.sp
-_opscen(osc::StratOperationalScenario) = osc.scen
+_strat_per(osc::StratOpScenario) = osc.sp
+_opscen(osc::StratOpScenario) = osc.scen
 
-mult_strat(osc::StratOperationalScenario) = osc.mult_sp
-mult_scen(osc::StratOperationalScenario) = osc.mult_scen
-probability(osc::StratOperationalScenario) = osc.probability
+mult_strat(osc::StratOpScenario) = osc.mult_sp
+mult_scen(osc::StratOpScenario) = osc.mult_scen
+probability(osc::StratOpScenario) = osc.probability
 
-StrategicIndexable(::Type{<:StratOperationalScenario}) = HasStratIndex()
-ScenarioIndexable(::Type{<:StratOperationalScenario}) = HasScenarioIndex()
+StrategicIndexable(::Type{<:StratOpScenario}) = HasStratIndex()
+ScenarioIndexable(::Type{<:StratOpScenario}) = HasScenarioIndex()
 
 # Provide a constructor to simplify the design
-function OperationalPeriod(osc::StratOperationalScenario, per)
+function OperationalPeriod(osc::StratOpScenario, per)
     mult = mult_strat(osc) * multiple(per)
     return OperationalPeriod(osc.sp, per, mult)
 end
 
-function Base.show(io::IO, osc::StratOperationalScenario)
+function Base.show(io::IO, osc::StratOpScenario)
     return print(io, "sp$(osc.sp)-sc$(osc.scen)")
 end
 
 # Add basic functions of iterators
-Base.length(osc::StratOperationalScenario) = length(osc.operational)
-function Base.eltype(::Type{StratOperationalScenario{T,OP}}) where {T,OP}
+Base.length(osc::StratOpScenario) = length(osc.operational)
+function Base.eltype(::Type{StratOpScenario{T,OP}}) where {T,OP}
     return OperationalPeriod{eltype(OP)}
 end
-function Base.iterate(osc::StratOperationalScenario, state = nothing)
+function Base.iterate(osc::StratOpScenario, state = nothing)
     next = isnothing(state) ? iterate(osc.operational) : iterate(osc.operational, state)
     isnothing(next) && return nothing
 
     return OperationalPeriod(osc, next[1]), next[2]
 end
-function Base.getindex(osc::StratOperationalScenario, index)
+function Base.getindex(osc::StratOpScenario, index)
     per = osc.operational[index]
     return OperationalPeriod(osc, per)
 end
-function Base.eachindex(osc::StratOperationalScenario)
+function Base.eachindex(osc::StratOpScenario)
     return eachindex(osc.operational)
 end
-function Base.last(osc::StratOperationalScenario)
+function Base.last(osc::StratOpScenario)
     per = last(osc.operational)
     return OperationalPeriod(osc, per)
 end
@@ -83,8 +83,8 @@ function opscenarios(sp::StrategicPeriod{S,T,OP}) where {S,T,OP}
     return StratOpScens(_strat_per(sp), mult_strat(sp), opscenarios(sp.operational))
 end
 # Provide a constructor to simplify the design
-function StratOperationalScenario(oscs::StratOpScens, scen::Int, per)
-    return StratOperationalScenario(
+function StratOpScenario(oscs::StratOpScens, scen::Int, per)
+    return StratOpScenario(
         _strat_per(oscs),
         scen,
         mult_strat(oscs),
@@ -101,27 +101,27 @@ function Base.iterate(oscs::StratOpScens, state = (nothing, 1))
     isnothing(next) && return nothing
 
     scen = state[2]
-    return StratOperationalScenario(oscs, _opscen(next[1]), next[1]), (next[2], scen + 1)
+    return StratOpScenario(oscs, _opscen(next[1]), next[1]), (next[2], scen + 1)
 end
 function Base.getindex(oscs::StratOpScens, index::Int)
     per = _oper_struct(oscs)[index]
-    return StratOperationalScenario(oscs, index, per)
+    return StratOpScenario(oscs, index, per)
 end
 function Base.eachindex(oscs::StratOpScens)
     return eachindex(_oper_struct(oscs))
 end
 function Base.last(oscs::StratOpScens)
     per = last(oscs.repr)
-    return StratOperationalScenario(oscs, _opscen(per), per)
+    return StratOpScenario(oscs, _opscen(per), per)
 end
 
 """
-    struct StratReprOpscenario{T, OP<:TimeStructure{T}} <: AbstractRepresentativePeriod{T}
+    struct StratReprOpScenario{T, OP<:TimeStructure{T}} <: AbstractRepresentativePeriod{T}
 
 A type representing a single representative period supporting iteration over its
-time periods. It is created when iterating through [`StratReprPeriods`](@ref).
+time periods. It is created when iterating through [`StratReprPers`](@ref).
 """
-struct StratReprOpscenario{T,OP<:TimeStructure{T}} <: AbstractOperationalScenario{T}
+struct StratReprOpScenario{T,OP<:TimeStructure{T}} <: AbstractOperationalScenario{T}
     sp::Int
     rp::Int
     scen::Int
@@ -132,63 +132,63 @@ struct StratReprOpscenario{T,OP<:TimeStructure{T}} <: AbstractOperationalScenari
     operational::OP
 end
 
-_opscen(osc::StratReprOpscenario) = osc.scen
-_rper(osc::StratReprOpscenario) = osc.rp
-_strat_per(osc::StratReprOpscenario) = osc.sp
+_opscen(osc::StratReprOpScenario) = osc.scen
+_rper(osc::StratReprOpScenario) = osc.rp
+_strat_per(osc::StratReprOpScenario) = osc.sp
 
-probability(osc::StratReprOpscenario) = osc.probability
-mult_strat(osc::StratReprOpscenario) = osc.mult_sp
-mult_repr(osc::StratReprOpscenario) = osc.mult_rp
-mult_scen(osc::StratReprOpscenario) = osc.mult_scen
+probability(osc::StratReprOpScenario) = osc.probability
+mult_strat(osc::StratReprOpScenario) = osc.mult_sp
+mult_repr(osc::StratReprOpScenario) = osc.mult_rp
+mult_scen(osc::StratReprOpScenario) = osc.mult_scen
 
-StrategicIndexable(::Type{<:StratReprOpscenario}) = HasStratIndex()
-function RepresentativeIndexable(::Type{<:StratReprOpscenario})
+StrategicIndexable(::Type{<:StratReprOpScenario}) = HasStratIndex()
+function RepresentativeIndexable(::Type{<:StratReprOpScenario})
     return HasReprIndex()
 end
-ScenarioIndexable(::Type{<:StratReprOpscenario}) = HasScenarioIndex()
+ScenarioIndexable(::Type{<:StratReprOpScenario}) = HasScenarioIndex()
 
 # Provide a constructor to simplify the design
-function OperationalPeriod(osc::StratReprOpscenario, per)
+function OperationalPeriod(osc::StratReprOpScenario, per)
     rper = ReprPeriod(_rper(osc), per, mult_repr(osc) * multiple(per))
     mult = mult_strat(osc) * mult_repr(osc) * multiple(per)
     return OperationalPeriod(_strat_per(osc), rper, mult)
 end
 
-function Base.show(io::IO, osc::StratReprOpscenario)
+function Base.show(io::IO, osc::StratReprOpScenario)
     return print(io, "sp$(osc.sp)-rp$(_rper(osc))-sc$(osc.opscen)")
 end
 
 # Add basic functions of iterators
-Base.length(osc::StratReprOpscenario) = length(osc.operational)
-function Base.eltype(::Type{StratReprOpscenario{T,OP}}) where {T,OP}
+Base.length(osc::StratReprOpScenario) = length(osc.operational)
+function Base.eltype(::Type{StratReprOpScenario{T,OP}}) where {T,OP}
     return OperationalPeriod{ReprPeriod{eltype(OP)}}
 end
-function Base.iterate(osc::StratReprOpscenario, state = nothing)
+function Base.iterate(osc::StratReprOpScenario, state = nothing)
     next = isnothing(state) ? iterate(osc.operational) : iterate(osc.operational, state)
     isnothing(next) && return nothing
 
     return OperationalPeriod(osc, next[1]), next[2]
 end
-function Base.getindex(osc::StratReprOpscenario, index)
+function Base.getindex(osc::StratReprOpScenario, index)
     per = osc.operational[index]
     return OperationalPeriod(osc, per)
 end
-function Base.eachindex(osc::StratReprOpscenario)
+function Base.eachindex(osc::StratReprOpScenario)
     return eachindex(osc.operational)
 end
-function Base.last(osc::StratReprOpscenario)
+function Base.last(osc::StratReprOpScenario)
     per = last(osc.operational)
     return OperationalPeriod(osc, per)
 end
 
 """
-    struct StratReprOpscenarios{T,OP<:TimeStructInnerIter{T}} <: TimeStructOuterIter{T}
+    struct StratReprOpScens{T,OP<:TimeStructInnerIter{T}} <: TimeStructOuterIter{T}
 
 Type for iterating through the individual operational scenarios of a
 [`StrategicPeriod`](@ref) time structure with [`RepresentativePeriods`](@ref). It is
 automatically created through the function [`opscenarios`](@ref).
 """
-struct StratReprOpscenarios{T,OP<:TimeStructInnerIter{T}} <: TimeStructOuterIter{T}
+struct StratReprOpScens{T,OP<:TimeStructInnerIter{T}} <: TimeStructOuterIter{T}
     sp::Int
     rp::Int
     mult_sp::Float64
@@ -196,16 +196,16 @@ struct StratReprOpscenarios{T,OP<:TimeStructInnerIter{T}} <: TimeStructOuterIter
     opscens::OP
 end
 
-_strat_per(oscs::StratReprOpscenarios) = oscs.sp
-_rper(oscs::StratReprOpscenarios) = oscs.rp
+_strat_per(oscs::StratReprOpScens) = oscs.sp
+_rper(oscs::StratReprOpScens) = oscs.rp
 
-mult_strat(oscs::StratReprOpscenarios) = oscs.mult_sp
-mult_repr(oscs::StratReprOpscenarios) = oscs.mult_rp
+mult_strat(oscs::StratReprOpScens) = oscs.mult_sp
+mult_repr(oscs::StratReprOpScens) = oscs.mult_rp
 
-_oper_struct(oscs::StratReprOpscenarios) = oscs.opscens
+_oper_struct(oscs::StratReprOpScens) = oscs.opscens
 
 function opscenarios(rp::StratReprPeriod{T,RepresentativePeriod{T,OP}}) where {T,OP}
-    return StratReprOpscenarios(
+    return StratReprOpScens(
         _strat_per(rp),
         _rper(rp),
         mult_strat(rp),
@@ -219,7 +219,7 @@ end
 
 """
 When the `TimeStructure` is a [`StrategicPeriod`](@ref) with [`RepresentativePeriods`](@ref),
-`opscenarios` returns a vector of [`StratReprOpscenario`](@ref)s.
+`opscenarios` returns a vector of [`StratReprOpScenario`](@ref)s.
 """
 function opscenarios(
     sp::StrategicPeriod{S1,T,RepresentativePeriods{S2,T,OP}},
@@ -228,8 +228,8 @@ function opscenarios(
 end
 
 # Provide a constructor to simplify the design
-function StratReprOpscenario(oscs::StratReprOpscenarios, scen, per)
-    return StratReprOpscenario(
+function StratReprOpScenario(oscs::StratReprOpScens, scen, per)
+    return StratReprOpScenario(
         _strat_per(oscs),
         _rper(oscs),
         scen,
@@ -242,26 +242,26 @@ function StratReprOpscenario(oscs::StratReprOpscenarios, scen, per)
 end
 
 # Add basic functions of iterators
-Base.length(oscs::StratReprOpscenarios) = length(_oper_struct(oscs))
-function Base.eltype(_::Type{StratReprOpscenarios{SC}}) where {T,OP,SC<:OpScens{T,OP}}
-    return StratReprOpscenario{T,eltype(SC)}
+Base.length(oscs::StratReprOpScens) = length(_oper_struct(oscs))
+function Base.eltype(_::Type{StratReprOpScens{SC}}) where {T,OP,SC<:OpScens{T,OP}}
+    return StratReprOpScenario{T,eltype(SC)}
 end
-function Base.iterate(oscs::StratReprOpscenarios, state = (nothing, 1))
+function Base.iterate(oscs::StratReprOpScens, state = (nothing, 1))
     next = isnothing(state[1]) ? iterate(_oper_struct(oscs)) : iterate(_oper_struct(oscs), state[1])
     isnothing(next) && return nothing
 
-    return StratReprOpscenario(oscs, state[2], next[1]), (next[2], state[2] + 1)
+    return StratReprOpScenario(oscs, state[2], next[1]), (next[2], state[2] + 1)
 end
-function Base.getindex(oscs::StratReprOpscenarios, index::Int)
+function Base.getindex(oscs::StratReprOpScens, index::Int)
     per = _oper_struct(oscs)[index]
-    return StratReprOpscenario(oscs, _opscen(per), per)
+    return StratReprOpScenario(oscs, _opscen(per), per)
 end
-function Base.eachindex(oscs::StratReprOpscenarios)
+function Base.eachindex(oscs::StratReprOpScens)
     return eachindex(_oper_struct(oscs))
 end
-function Base.last(oscs::StratReprOpscenarios)
+function Base.last(oscs::StratReprOpScens)
     per = last(_oper_struct(oscs))
-    return StratReprOpscenario(oscs, _opscen(per), per)
+    return StratReprOpScenario(oscs, _opscen(per), per)
 end
 
 """
@@ -271,14 +271,14 @@ correct behavior based on the substructure.
 opscenarios(ts::SingleStrategicPeriod) = opscenarios(ts.ts)
 """
 When the `TimeStructure` is a [`TwoLevel`](@ref), `opscenarios` returns a vector of
-[`StratOperationalScenario`](@ref)s.
+[`StratOpScenario`](@ref)s.
 """
 function opscenarios(ts::TwoLevel{S,T,OP}) where {S,T,OP}
     return collect(Iterators.flatten(opscenarios(sp) for sp in strategic_periods(ts)))
 end
 """
 When the `TimeStructure` is a [`TwoLevel`](@ref) with [`RepresentativePeriods`](@ref),
-`opscenarios` returns a vector of [`StratReprOpscenario`](@ref)s.
+`opscenarios` returns a vector of [`StratReprOpScenario`](@ref)s.
 """
 function opscenarios(ts::TwoLevel{S1,T,RepresentativePeriods{S2,T,OP}}) where {S1,S2,T,OP}
     return collect(

--- a/src/op_scenarios/strat_periods.jl
+++ b/src/op_scenarios/strat_periods.jl
@@ -124,21 +124,22 @@ time periods. It is created when iterating through [`StratReprPeriods`](@ref).
 struct StratReprOpscenario{T,OP<:TimeStructure{T}} <: AbstractOperationalScenario{T}
     sp::Int
     rp::Int
-    opscen::Int
+    scen::Int
     mult_sp::Float64
     mult_rp::Float64
+    mult_scen::Float64
     probability::Float64
     operational::OP
 end
 
-_opscen(osc::StratReprOpscenario) = osc.opscen
+_opscen(osc::StratReprOpscenario) = osc.scen
 _rper(osc::StratReprOpscenario) = osc.rp
 _strat_per(osc::StratReprOpscenario) = osc.sp
 
 probability(osc::StratReprOpscenario) = osc.probability
-mult_scen(osc::StratReprOpscenario) = osc.multiple_scen
-mult_repr(osc::StratReprOpscenario) = osc.mult_rp
 mult_strat(osc::StratReprOpscenario) = osc.mult_sp
+mult_repr(osc::StratReprOpscenario) = osc.mult_rp
+mult_scen(osc::StratReprOpscenario) = osc.mult_scen
 
 StrategicIndexable(::Type{<:StratReprOpscenario}) = HasStratIndex()
 function RepresentativeIndexable(::Type{<:StratReprOpscenario})
@@ -234,6 +235,7 @@ function StratReprOpscenario(oscs::StratReprOpscenarios, scen, per)
         scen,
         mult_strat(oscs),
         mult_repr(oscs),
+        mult_scen(per),
         probability(per),
         per,
     )

--- a/src/op_scenarios/strat_periods.jl
+++ b/src/op_scenarios/strat_periods.jl
@@ -36,7 +36,7 @@ end
 # Add basic functions of iterators
 Base.length(osc::StratOperationalScenario) = length(osc.operational)
 function Base.eltype(::Type{StratOperationalScenario{T,OP}}) where {T,OP}
-    return OperationalPeriod
+    return OperationalPeriod{eltype(OP)}
 end
 function Base.iterate(osc::StratOperationalScenario, state = nothing)
     next = isnothing(state) ? iterate(osc.operational) : iterate(osc.operational, state)
@@ -160,7 +160,7 @@ end
 # Add basic functions of iterators
 Base.length(osc::StratReprOpscenario) = length(osc.operational)
 function Base.eltype(::Type{StratReprOpscenario{T,OP}}) where {T,OP}
-    return OperationalPeriod
+    return OperationalPeriod{ReprPeriod{eltype(OP)}}
 end
 function Base.iterate(osc::StratReprOpscenario, state = nothing)
     next = isnothing(state) ? iterate(osc.operational) : iterate(osc.operational, state)

--- a/src/op_scenarios/tree_periods.jl
+++ b/src/op_scenarios/tree_periods.jl
@@ -8,8 +8,7 @@ iteration over its time periods. It is created through iterating through
 It is equivalent to a [`StratOpScenario`](@ref) of a [`TwoLevel`](@ref) time
 structure when utilizing a [`TwoLevelTree`](@ref).
 """
-struct StratNodeOpScenario{T,OP<:TimeStructure{T}} <:
-       AbstractOperationalScenario{T}
+struct StratNodeOpScenario{T,OP<:TimeStructure{T}} <: AbstractOperationalScenario{T}
     sp::Int
     branch::Int
     scen::Int
@@ -32,10 +31,7 @@ probability_branch(osc::StratNodeOpScenario) = osc.prob_branch
 _oper_struct(osc::StratNodeOpScenario) = osc.operational
 
 # Provide a constructor to simplify the design
-function TreePeriod(
-    osc::StratNodeOpScenario,
-    per::TimePeriod,
-)
+function TreePeriod(osc::StratNodeOpScenario, per::TimePeriod)
     mult = mult_strat(osc) * multiple(per)
     return TreePeriod(_strat_per(osc), _branch(osc), per, mult, probability_branch(osc))
 end
@@ -142,10 +138,7 @@ end
 ScenarioIndexable(::Type{<:StratNodeReprOpScenario}) = HasScenarioIndex()
 
 # Provide a constructor to simplify the design
-function TreePeriod(
-    osc::StratNodeReprOpScenario,
-    per::TimePeriod,
-)
+function TreePeriod(osc::StratNodeReprOpScenario, per::TimePeriod)
     rper = ReprPeriod(_rper(osc), per, mult_repr(osc) * multiple(per))
     mult = mult_strat(osc) * mult_repr(osc) * multiple(per)
     return TreePeriod(_strat_per(osc), _branch(osc), rper, mult, probability_branch(osc))

--- a/src/op_scenarios/tree_periods.jl
+++ b/src/op_scenarios/tree_periods.jl
@@ -34,10 +34,10 @@ _oper_struct(osc::StratNodeOperationalScenario) = osc.operational
 # Provide a constructor to simplify the design
 function TreePeriod(
     osc::StratNodeOperationalScenario,
-    per::P,
-) where {P<:Union{TimePeriod,AbstractOperationalScenario}}
+    per::TimePeriod,
+)
     mult = mult_strat(osc) * multiple(per)
-    return TreePeriod(_strat_per(osc), _branch(osc), probability_branch(osc), mult, per)
+    return TreePeriod(_strat_per(osc), _branch(osc), per, mult, probability_branch(osc))
 end
 
 function StrategicTreeIndexable(::Type{<:StratNodeOperationalScenario})
@@ -144,11 +144,11 @@ ScenarioIndexable(::Type{<:StratNodeReprOpScenario}) = HasScenarioIndex()
 # Provide a constructor to simplify the design
 function TreePeriod(
     osc::StratNodeReprOpScenario,
-    per::P,
-) where {P<:Union{TimePeriod,AbstractOperationalScenario}}
+    per::TimePeriod,
+)
     rper = ReprPeriod(_rper(osc), per, mult_repr(osc) * multiple(per))
     mult = mult_strat(osc) * mult_repr(osc) * multiple(per)
-    return TreePeriod(_strat_per(osc), _branch(osc), probability_branch(osc), mult, rper)
+    return TreePeriod(_strat_per(osc), _branch(osc), rper, mult, probability_branch(osc))
 end
 
 # Adding methods to existing Julia functions

--- a/src/op_scenarios/tree_periods.jl
+++ b/src/op_scenarios/tree_periods.jl
@@ -49,7 +49,7 @@ StrategicIndexable(::Type{<:StratNodeOperationalScenario}) = HasStratIndex()
 function Base.show(io::IO, osc::StratNodeOperationalScenario)
     return print(io, "sp$(_strat_per(osc))-br$(_branch(osc))-sc$(_opscen(osc))")
 end
-Base.eltype(_::StratNodeOperationalScenario) = TreePeriod
+Base.eltype(_::StratNodeOperationalScenario{T,OP}) where {T,OP} = TreePeriod{eltype(op)}
 
 """
     struct StratNodeOpScens <: AbstractTreeStructure
@@ -158,7 +158,7 @@ function Base.show(io::IO, osc::StratNodeReprOpScenario)
         "sp$(_strat_per(osc))-br$(_branch(osc))-rp$(_rper(osc))-sc$(_opscen(osc))",
     )
 end
-Base.eltype(_::StratNodeReprOpScenario) = TreePeriod
+Base.eltype(_::StratNodeReprOpScenario{T,OP}) where {T,OP} = TreePeriod{eltype(op)}
 
 """
     struct StratNodeReprOpScens <: AbstractTreeStructure

--- a/src/op_scenarios/tree_periods.jl
+++ b/src/op_scenarios/tree_periods.jl
@@ -52,17 +52,17 @@ end
 Base.eltype(_::StratNodeOperationalScenario{T,OP}) where {T,OP} = TreePeriod{eltype(op)}
 
 """
-    struct StratNodeOpScens <: AbstractTreeStructure
+    struct StratNodeOpScens{T,OP<:TimeStructInnerIter{T}} <: AbstractTreeStructure{T}
 
 Type for iterating through the individual operational scenarios of a [`StratNode`](@ref).
 It is automatically created through the function [`opscenarios`](@ref).
 """
-struct StratNodeOpScens <: AbstractTreeStructure
+struct StratNodeOpScens{T,OP<:TimeStructInnerIter{T}} <: AbstractTreeStructure{T}
     sp::Int
     branch::Int
     mult_sp::Float64
     prob_branch::Float64
-    opscens::Any
+    opscens::OP
 end
 
 _strat_per(oscs::StratNodeOpScens) = oscs.sp
@@ -161,20 +161,20 @@ end
 Base.eltype(_::StratNodeReprOpScenario{T,OP}) where {T,OP} = TreePeriod{eltype(op)}
 
 """
-    struct StratNodeReprOpScens <: AbstractTreeStructure
+    struct StratNodeReprOpScens{T,OP<:TimeStructInnerIter{T}} <: AbstractTreeStructure{T}
 
 Type for iterating through the individual operational scenarios of a
 [`StratNodeReprPeriod`](@ref). It is automatically created through the function
 [`opscenarios`](@ref).
 """
-struct StratNodeReprOpScens <: AbstractTreeStructure
+struct StratNodeReprOpScens{T,OP<:TimeStructInnerIter{T}} <: AbstractTreeStructure{T}
     sp::Int
     branch::Int
     rp::Int
     mult_sp::Float64
     mult_rp::Float64
     prob_branch::Float64
-    opscens::Any
+    opscens::OP
 end
 
 _strat_per(oscs::StratNodeReprOpScens) = oscs.sp

--- a/src/op_scenarios/tree_periods.jl
+++ b/src/op_scenarios/tree_periods.jl
@@ -1,14 +1,14 @@
 """
-    struct StratNodeOperationalScenario{T,OP<:TimeStructure{T}}  <: AbstractOperationalScenario{T}
+    struct StratNodeOpScenario{T,OP<:TimeStructure{T}}  <: AbstractOperationalScenario{T}
 
 A structure representing a single operational scenario for a strategic node supporting
 iteration over its time periods. It is created through iterating through
 [`StratNodeOpScens`](@ref).
 
-It is equivalent to a [`StratOperationalScenario`](@ref) of a [`TwoLevel`](@ref) time
+It is equivalent to a [`StratOpScenario`](@ref) of a [`TwoLevel`](@ref) time
 structure when utilizing a [`TwoLevelTree`](@ref).
 """
-struct StratNodeOperationalScenario{T,OP<:TimeStructure{T}} <:
+struct StratNodeOpScenario{T,OP<:TimeStructure{T}} <:
        AbstractOperationalScenario{T}
     sp::Int
     branch::Int
@@ -20,36 +20,36 @@ struct StratNodeOperationalScenario{T,OP<:TimeStructure{T}} <:
     operational::OP
 end
 
-_strat_per(osc::StratNodeOperationalScenario) = osc.sp
-_branch(osc::StratNodeOperationalScenario) = osc.branch
-_opscen(osc::StratNodeOperationalScenario) = osc.scen
+_strat_per(osc::StratNodeOpScenario) = osc.sp
+_branch(osc::StratNodeOpScenario) = osc.branch
+_opscen(osc::StratNodeOpScenario) = osc.scen
 
-mult_strat(osc::StratNodeOperationalScenario) = osc.mult_sp
-mult_scen(osc::StratNodeOperationalScenario) = osc.mult_scen
-probability(osc::StratNodeOperationalScenario) = osc.prob_branch * prob_scen
-probability_branch(osc::StratNodeOperationalScenario) = osc.prob_branch
+mult_strat(osc::StratNodeOpScenario) = osc.mult_sp
+mult_scen(osc::StratNodeOpScenario) = osc.mult_scen
+probability(osc::StratNodeOpScenario) = osc.prob_branch * prob_scen
+probability_branch(osc::StratNodeOpScenario) = osc.prob_branch
 
-_oper_struct(osc::StratNodeOperationalScenario) = osc.operational
+_oper_struct(osc::StratNodeOpScenario) = osc.operational
 
 # Provide a constructor to simplify the design
 function TreePeriod(
-    osc::StratNodeOperationalScenario,
+    osc::StratNodeOpScenario,
     per::TimePeriod,
 )
     mult = mult_strat(osc) * multiple(per)
     return TreePeriod(_strat_per(osc), _branch(osc), per, mult, probability_branch(osc))
 end
 
-function StrategicTreeIndexable(::Type{<:StratNodeOperationalScenario})
+function StrategicTreeIndexable(::Type{<:StratNodeOpScenario})
     return HasStratTreeIndex()
 end
-StrategicIndexable(::Type{<:StratNodeOperationalScenario}) = HasStratIndex()
+StrategicIndexable(::Type{<:StratNodeOpScenario}) = HasStratIndex()
 
 # Adding methods to existing Julia functions
-function Base.show(io::IO, osc::StratNodeOperationalScenario)
+function Base.show(io::IO, osc::StratNodeOpScenario)
     return print(io, "sp$(_strat_per(osc))-br$(_branch(osc))-sc$(_opscen(osc))")
 end
-Base.eltype(_::StratNodeOperationalScenario{T,OP}) where {T,OP} = TreePeriod{eltype(op)}
+Base.eltype(_::StratNodeOpScenario{T,OP}) where {T,OP} = TreePeriod{eltype(op)}
 
 """
     struct StratNodeOpScens{T,OP<:TimeStructInnerIter{T}} <: AbstractTreeStructure{T}
@@ -88,7 +88,7 @@ function opscenarios(n::StratNode{S,T,OP}) where {S,T,OP<:TimeStructure{T}}
 end
 
 function strat_node_period(oscs::StratNodeOpScens, next, state)
-    return StratNodeOperationalScenario(
+    return StratNodeOpScenario(
         _strat_per(oscs),
         _branch(oscs),
         state,
@@ -100,7 +100,7 @@ function strat_node_period(oscs::StratNodeOpScens, next, state)
     )
 end
 
-Base.eltype(_::StratNodeOpScens) = StratNodeOperationalScenario
+Base.eltype(_::StratNodeOpScens) = StratNodeOpScenario
 
 """
     struct StratNodeReprOpScenario{T} <: AbstractOperationalScenario{T}
@@ -245,11 +245,11 @@ end
 
 """
 When the `TimeStructure` is a [`TwoLevelTree`](@ref), `opscenarios` returns an `Array` of
-all [`StratNodeOperationalScenario`](@ref)s or [`StratNodeReprOpScenario`](@ref)s types,
+all [`StratNodeOpScenario`](@ref)s or [`StratNodeReprOpScenario`](@ref)s types,
 dependening on whether the [`TwoLevelTree`](@ref) includes [`RepresentativePeriods`](@ref)
 or not.
 
-These are equivalent to a [`StratOperationalScenario`](@ref) and [`StratReprOpscenario`](@ref)
+These are equivalent to a [`StratOpScenario`](@ref) and [`StratReprOpScenario`](@ref)
 of a [`TwoLevel`](@ref) time structure.
 """
 function opscenarios(ts::TwoLevelTree)

--- a/src/representative/core_types.jl
+++ b/src/representative/core_types.jl
@@ -156,7 +156,7 @@ function Base.last(rpers::RepresentativePeriods)
 end
 
 """
-	ReprPeriod{P} <: TimePeriod where {P<:TimePeriod}
+	struct ReprPeriod{P} <: TimePeriod where {P<:TimePeriod}
 
 Time period for a single operational period. It is created through iterating through a
 [`RepresentativePeriods`](@ref) time structure. It is as well created as period within

--- a/src/representative/core_types.jl
+++ b/src/representative/core_types.jl
@@ -165,7 +165,7 @@ Time period for a single operational period. It is created through iterating thr
 struct ReprPeriod{P} <: TimePeriod where {P<:TimePeriod}
     rp::Int
     period::P
-    mult::Float64
+    multiple::Float64
 end
 _period(t::ReprPeriod) = t.period
 
@@ -175,7 +175,7 @@ _rper(t::ReprPeriod) = t.rp
 
 isfirst(t::ReprPeriod) = isfirst(_period(t))
 duration(t::ReprPeriod) = duration(_period(t))
-multiple(t::ReprPeriod) = t.mult
+multiple(t::ReprPeriod) = t.multiple
 probability(t::ReprPeriod) = probability(_period(t))
 
 Base.show(io::IO, t::ReprPeriod) = print(io, "rp$(t.rp)-$(_period(t))")

--- a/src/representative/core_types.jl
+++ b/src/representative/core_types.jl
@@ -167,18 +167,20 @@ struct ReprPeriod{P} <: TimePeriod where {P<:TimePeriod}
     period::P
     mult::Float64
 end
-_oper(t::ReprPeriod) = _oper(t.period)
-_opscen(t::ReprPeriod) = _opscen(t.period)
+_period(t::ReprPeriod) = t.period
+
+_oper(t::ReprPeriod) = _oper(_period(t))
+_opscen(t::ReprPeriod) = _opscen(_period(t))
 _rper(t::ReprPeriod) = t.rp
 
-isfirst(t::ReprPeriod) = isfirst(t.period)
-duration(t::ReprPeriod) = duration(t.period)
+isfirst(t::ReprPeriod) = isfirst(_period(t))
+duration(t::ReprPeriod) = duration(_period(t))
 multiple(t::ReprPeriod) = t.mult
-probability(t::ReprPeriod) = probability(t.period)
+probability(t::ReprPeriod) = probability(_period(t))
 
-Base.show(io::IO, t::ReprPeriod) = print(io, "rp$(t.rp)-$(t.period)")
+Base.show(io::IO, t::ReprPeriod) = print(io, "rp$(t.rp)-$(_period(t))")
 function Base.isless(t1::ReprPeriod, t2::ReprPeriod)
-    return t1.rp < t2.rp || (t1.rp == t2.rp && t1.period < t2.period)
+    return _rper(t1) < _rper(t2) || (_rper(t1) == _rper(t2) && _period(t1) < _period(t2))
 end
 
 # Convenience constructor for the type

--- a/src/representative/rep_periods.jl
+++ b/src/representative/rep_periods.jl
@@ -108,8 +108,8 @@ Base.show(io::IO, rp::RepresentativePeriod) = print(io, "rp-$(_rper(rp))")
 # Provide a constructor to simplify the design
 function ReprPeriod(
     rp::RepresentativePeriod,
-    per::P,
-) where {P<:Union{TimePeriod,TimeStructure}}
+    per::TimePeriod,
+)
     mult = mult_repr(rp) * multiple(per)
     return ReprPeriod(_rper(rp), per, mult)
 end

--- a/src/representative/rep_periods.jl
+++ b/src/representative/rep_periods.jl
@@ -91,7 +91,7 @@ repr_periods(ts::TimeStructure) = SingleReprPeriodWrapper(ts)
     struct RepresentativePeriod{T,OP<:TimeStructure{T}} <: AbstractRepresentativePeriod{T}
 
 A type representing a single representative period supporting iteration over its
-time periods. It is created when iterating through [`ReprPeriods`](@ref).
+time periods. It is created when iterating through [`ReprPers`](@ref).
 """
 struct RepresentativePeriod{T,OP<:TimeStructure{T}} <: AbstractRepresentativePeriod{T}
     rp::Int
@@ -138,26 +138,26 @@ function Base.last(rp::RepresentativePeriod)
 end
 
 """
-    struct ReprPeriods{S,T,OP} <: TimeStructInnerIter{T}
+    struct ReprPers{S,T,OP} <: TimeStructInnerIter{T}
 
 Type for iterating through the individual representative periods of a
 [`RepresentativePeriods`](@ref) time structure. It is automatically created through the
 function [`repr_periods`](@ref).
 """
-struct ReprPeriods{S,T,OP} <: TimeStructInnerIter{T}
+struct ReprPers{S,T,OP} <: TimeStructInnerIter{T}
     ts::RepresentativePeriods{S,T,OP}
 end
 
-_oper_struct(rpers::ReprPeriods) = rpers.ts
+_oper_struct(rpers::ReprPers) = rpers.ts
 
 """
 When the `TimeStructure` is a [`RepresentativePeriods`](@ref), `repr_periods` returns the
-iterator [`ReprPeriods`](@ref).
+iterator [`ReprPers`](@ref).
 """
-repr_periods(ts::RepresentativePeriods) = ReprPeriods(ts)
+repr_periods(ts::RepresentativePeriods) = ReprPers(ts)
 
 # Provide a constructor to simplify the design
-function RepresentativePeriod(rpers::ReprPeriods, per::Int)
+function RepresentativePeriod(rpers::ReprPers, per::Int)
     return RepresentativePeriod(
         per,
         _multiple_adj(_oper_struct(rpers), per),
@@ -166,20 +166,20 @@ function RepresentativePeriod(rpers::ReprPeriods, per::Int)
 end
 
 # Add basic functions of iterators
-Base.length(rpers::ReprPeriods) = _oper_struct(rpers).len
-function Base.eltype(_::ReprPeriods{S,T,OP}) where {S,T,OP<:TimeStructure{T}}
+Base.length(rpers::ReprPers) = _oper_struct(rpers).len
+function Base.eltype(_::ReprPers{S,T,OP}) where {S,T,OP<:TimeStructure{T}}
     return RepresentativePeriod{T,OP}
 end
-function Base.iterate(rpers::ReprPeriods, state = nothing)
+function Base.iterate(rpers::ReprPers, state = nothing)
     per = isnothing(state) ? 1 : state + 1
     per > length(rpers) && return nothing
 
     return RepresentativePeriod(rpers, per), per
 end
-function Base.getindex(rpers::ReprPeriods, index::Int)
+function Base.getindex(rpers::ReprPers, index::Int)
     return RepresentativePeriod(rpers, index)
 end
-function Base.eachindex(rpers::ReprPeriods)
+function Base.eachindex(rpers::ReprPers)
     return eachindex(_oper_struct(rpers).rep_periods)
 end
-Base.last(rpers::ReprPeriods) = RepresentativePeriod(rpers, length(rpers))
+Base.last(rpers::ReprPers) = RepresentativePeriod(rpers, length(rpers))

--- a/src/representative/rep_periods.jl
+++ b/src/representative/rep_periods.jl
@@ -1,5 +1,5 @@
 """
-    AbstractRepresentativePeriod{T} <: TimeStructure{T}
+    abstract type AbstractRepresentativePeriod{T} <: TimeStructure{T}
 
 Abstract type used for time structures that represent a representative period.
 These periods are obtained when iterating through the representative periods of a time
@@ -28,7 +28,7 @@ RepresentativeIndexable(::Type{<:AbstractRepresentativePeriod}) = HasReprIndex()
 RepresentativeIndexable(::Type{<:TimePeriod}) = HasReprIndex()
 
 """
-    SingleReprPeriod{T,OP<:TimeStructure{T}} <: AbstractRepresentativePeriod{T}
+    struct SingleReprPeriod{T,OP<:TimeStructure{T}} <: AbstractRepresentativePeriod{T}
 
 A type representing a single representative period supporting iteration over its
 time periods. It is created when iterating through [`SingleReprPeriodWrapper`](@ref).
@@ -52,15 +52,17 @@ Base.eltype(::Type{SingleReprPeriod{T,OP}}) where {T,OP} = eltype(OP)
 Base.last(rp::SingleReprPeriod) = last(rp.ts)
 
 """
-    SingleReprPeriodWrapper{T,OP<:TimeStructure{T}} <: TimeStructure{T}
+    struct SingleReprPeriodWrapper{T,OP<:TimeStructure{T}} <: TimeStructInnerIter{T}
 
 Type for iterating through the individual representative periods of a time structure
 without [`RepresentativePeriods`](@ref). It is automatically created through the function
 [`repr_periods`](@ref).
 """
-struct SingleReprPeriodWrapper{T,OP<:TimeStructure{T}} <: TimeStructure{T}
+struct SingleReprPeriodWrapper{T,OP<:TimeStructure{T}} <: TimeStructInnerIter{T}
     ts::OP
 end
+
+_oper_struct(rpers::SingleReprPeriodWrapper) = rpers.ts
 
 # Add basic functions of iterators
 Base.length(rpers::SingleReprPeriodWrapper) = 1
@@ -69,9 +71,9 @@ function Base.eltype(::Type{SingleReprPeriodWrapper{T,OP}}) where {T,OP}
 end
 function Base.iterate(rpers::SingleReprPeriodWrapper, state = nothing)
     !isnothing(state) && return nothing
-    return SingleReprPeriod(rpers.ts), 1
+    return SingleReprPeriod(_oper_struct(rpers)), 1
 end
-Base.last(rpers::SingleReprPeriodWrapper) = SingleReprPeriod(rpers.ts)
+Base.last(rpers::SingleReprPeriodWrapper) = SingleReprPeriod(_oper_struct(rpers))
 
 """
     repr_periods(ts::TimeStructure)
@@ -86,7 +88,7 @@ When the `TimeStructure` is a `TimeStructure`, `repr_periods` returns a
 repr_periods(ts::TimeStructure) = SingleReprPeriodWrapper(ts)
 
 """
-    RepresentativePeriod{T,OP<:TimeStructure{T}} <: AbstractRepresentativePeriod{T}
+    struct RepresentativePeriod{T,OP<:TimeStructure{T}} <: AbstractRepresentativePeriod{T}
 
 A type representing a single representative period supporting iteration over its
 time periods. It is created when iterating through [`ReprPeriods`](@ref).
@@ -136,15 +138,17 @@ function Base.last(rp::RepresentativePeriod)
 end
 
 """
-    ReprPeriods{S,T,OP}
+    struct ReprPeriods{S,T,OP} <: TimeStructInnerIter{T}
 
 Type for iterating through the individual representative periods of a
 [`RepresentativePeriods`](@ref) time structure. It is automatically created through the
 function [`repr_periods`](@ref).
 """
-struct ReprPeriods{S,T,OP}
+struct ReprPeriods{S,T,OP} <: TimeStructInnerIter{T}
     ts::RepresentativePeriods{S,T,OP}
 end
+
+_oper_struct(rpers::ReprPeriods) = rpers.ts
 
 """
 When the `TimeStructure` is a [`RepresentativePeriods`](@ref), `repr_periods` returns the
@@ -156,13 +160,13 @@ repr_periods(ts::RepresentativePeriods) = ReprPeriods(ts)
 function RepresentativePeriod(rpers::ReprPeriods, per::Int)
     return RepresentativePeriod(
         per,
-        _multiple_adj(rpers.ts, per),
-        rpers.ts.rep_periods[per],
+        _multiple_adj(_oper_struct(rpers), per),
+        _oper_struct(rpers).rep_periods[per],
     )
 end
 
 # Add basic functions of iterators
-Base.length(rpers::ReprPeriods) = rpers.ts.len
+Base.length(rpers::ReprPeriods) = _oper_struct(rpers).len
 function Base.eltype(_::ReprPeriods{S,T,OP}) where {S,T,OP<:TimeStructure{T}}
     return RepresentativePeriod{T,OP}
 end
@@ -176,6 +180,6 @@ function Base.getindex(rpers::ReprPeriods, index::Int)
     return RepresentativePeriod(rpers, index)
 end
 function Base.eachindex(rpers::ReprPeriods)
-    return eachindex(rpers.ts.rep_periods)
+    return eachindex(_oper_struct(rpers).rep_periods)
 end
 Base.last(rpers::ReprPeriods) = RepresentativePeriod(rpers, length(rpers))

--- a/src/representative/rep_periods.jl
+++ b/src/representative/rep_periods.jl
@@ -106,10 +106,7 @@ mult_repr(rp::RepresentativePeriod) = rp.mult_rp
 Base.show(io::IO, rp::RepresentativePeriod) = print(io, "rp-$(_rper(rp))")
 
 # Provide a constructor to simplify the design
-function ReprPeriod(
-    rp::RepresentativePeriod,
-    per::TimePeriod,
-)
+function ReprPeriod(rp::RepresentativePeriod, per::TimePeriod)
     mult = mult_repr(rp) * multiple(per)
     return ReprPeriod(_rper(rp), per, mult)
 end

--- a/src/representative/strat_periods.jl
+++ b/src/representative/strat_periods.jl
@@ -85,7 +85,7 @@ function StratReprPeriod(rpers::StratReprPeriods, state, per)
 end
 
 # Add basic functions of iterators
-Base.length(rpers::StratReprPeriods) = length(rpers.repr)
+Base.length(rpers::StratReprPeriods) = length(_oper_struct(rpers))
 function Base.iterate(rpers::StratReprPeriods, state = (nothing, 1))
     next = isnothing(state[1]) ? iterate(_oper_struct(rpers)) : iterate(_oper_struct(rpers), state[1])
     isnothing(next) && return nothing

--- a/src/representative/strat_periods.jl
+++ b/src/representative/strat_periods.jl
@@ -33,7 +33,7 @@ end
 
 # Add basic functions of iterators
 Base.length(rp::StratReprPeriod) = length(rp.operational)
-Base.eltype(_::Type{StratReprPeriod{T,OP}}) where {T,OP} = OperationalPeriod
+Base.eltype(_::Type{StratReprPeriod{T,OP}}) where {T,OP} = OperationalPeriod{eltype(OP)}
 function Base.iterate(rp::StratReprPeriod, state = nothing)
     next = isnothing(state) ? iterate(rp.operational) : iterate(rp.operational, state)
     isnothing(next) && return nothing

--- a/src/representative/strat_periods.jl
+++ b/src/representative/strat_periods.jl
@@ -87,7 +87,9 @@ end
 # Add basic functions of iterators
 Base.length(rpers::StratReprPers) = length(_oper_struct(rpers))
 function Base.iterate(rpers::StratReprPers, state = (nothing, 1))
-    next = isnothing(state[1]) ? iterate(_oper_struct(rpers)) : iterate(_oper_struct(rpers), state[1])
+    next =
+        isnothing(state[1]) ? iterate(_oper_struct(rpers)) :
+        iterate(_oper_struct(rpers), state[1])
     isnothing(next) && return nothing
 
     return StratReprPeriod(rpers, state[2], next[1]), (next[2], state[2] + 1)

--- a/src/representative/strat_periods.jl
+++ b/src/representative/strat_periods.jl
@@ -2,7 +2,7 @@
     struct StratReprPeriod{T,OP<:TimeStructure{T}} <: AbstractRepresentativePeriod{T}
 
 A type representing a single representative period supporting iteration over its
-time periods. It is created when iterating through [`StratReprPeriods`](@ref).
+time periods. It is created when iterating through [`StratReprPers`](@ref).
 """
 struct StratReprPeriod{T,OP<:TimeStructure{T}} <: AbstractRepresentativePeriod{T}
     sp::Int
@@ -53,52 +53,52 @@ function Base.last(rp::StratReprPeriod)
 end
 
 """
-    struct StratReprPeriods{T,OP<:TimeStructInnerIter{T}} <: TimeStructOuterIter{T}
+    struct StratReprPers{T,OP<:TimeStructInnerIter{T}} <: TimeStructOuterIter{T}
 
 Type for iterating through the individual representative periods of a
 [`StrategicPeriod`](@ref) time structure. It is automatically created through the function
 [`repr_periods`](@ref).
 """
-struct StratReprPeriods{T,OP<:TimeStructInnerIter{T}} <: TimeStructOuterIter{T}
+struct StratReprPers{T,OP<:TimeStructInnerIter{T}} <: TimeStructOuterIter{T}
     sp::Int
     mult_sp::Float64
     repr::OP
 end
 
-_strat_per(rpers::StratReprPeriods) = rpers.sp
+_strat_per(rpers::StratReprPers) = rpers.sp
 
-mult_strat(rpers::StratReprPeriods) = rpers.mult_sp
+mult_strat(rpers::StratReprPers) = rpers.mult_sp
 
-_oper_struct(rpers::StratReprPeriods) = rpers.repr
+_oper_struct(rpers::StratReprPers) = rpers.repr
 
 """
 When the `TimeStructure` is a [`StrategicPeriod`](@ref), `repr_periods` returns the iterator
-[`StratReprPeriods`](@ref).
+[`StratReprPers`](@ref).
 """
 function repr_periods(sp::StrategicPeriod{S,T,OP}) where {S,T,OP}
-    return StratReprPeriods(_strat_per(sp), mult_strat(sp), repr_periods(sp.operational))
+    return StratReprPers(_strat_per(sp), mult_strat(sp), repr_periods(sp.operational))
 end
 
 # Provide a constructor to simplify the design
-function StratReprPeriod(rpers::StratReprPeriods, state, per)
+function StratReprPeriod(rpers::StratReprPers, state, per)
     return StratReprPeriod(_strat_per(rpers), state, mult_strat(rpers), mult_repr(per), per)
 end
 
 # Add basic functions of iterators
-Base.length(rpers::StratReprPeriods) = length(_oper_struct(rpers))
-function Base.iterate(rpers::StratReprPeriods, state = (nothing, 1))
+Base.length(rpers::StratReprPers) = length(_oper_struct(rpers))
+function Base.iterate(rpers::StratReprPers, state = (nothing, 1))
     next = isnothing(state[1]) ? iterate(_oper_struct(rpers)) : iterate(_oper_struct(rpers), state[1])
     isnothing(next) && return nothing
 
     return StratReprPeriod(rpers, state[2], next[1]), (next[2], state[2] + 1)
 end
-function Base.getindex(rpers::StratReprPeriods, index::Int)
+function Base.getindex(rpers::StratReprPers, index::Int)
     return StratReprPeriod(rpers, index)
 end
-function Base.eachindex(rpers::StratReprPeriods)
+function Base.eachindex(rpers::StratReprPers)
     return eachindex(_oper_struct(rpers))
 end
-function Base.last(rpers::StratReprPeriods)
+function Base.last(rpers::StratReprPers)
     per = last(_oper_struct(rpers))
     return StratReprPeriod(rpers, _rper(per), per)
 end

--- a/src/representative/tree_periods.jl
+++ b/src/representative/tree_periods.jl
@@ -33,10 +33,7 @@ StrategicTreeIndexable(::Type{<:StratNodeReprPeriod}) = HasStratTreeIndex()
 StrategicIndexable(::Type{<:StratNodeReprPeriod}) = HasStratIndex()
 
 # Provide a constructor to simplify the design
-function TreePeriod(
-    rp::StratNodeReprPeriod,
-    per::TimePeriod,
-)
+function TreePeriod(rp::StratNodeReprPeriod, per::TimePeriod)
     mult = mult_strat(rp) * multiple(per)
     return TreePeriod(_strat_per(rp), _branch(rp), per, mult, probability_branch(rp))
 end

--- a/src/representative/tree_periods.jl
+++ b/src/representative/tree_periods.jl
@@ -35,10 +35,10 @@ StrategicIndexable(::Type{<:StratNodeReprPeriod}) = HasStratIndex()
 # Provide a constructor to simplify the design
 function TreePeriod(
     rp::StratNodeReprPeriod,
-    per::P,
-) where {P<:Union{TimePeriod,AbstractRepresentativePeriod}}
+    per::TimePeriod,
+)
     mult = mult_strat(rp) * multiple(per)
-    return TreePeriod(_strat_per(rp), _branch(rp), probability_branch(rp), mult, per)
+    return TreePeriod(_strat_per(rp), _branch(rp), per, mult, probability_branch(rp))
 end
 
 # Adding methods to existing Julia functions

--- a/src/representative/tree_periods.jl
+++ b/src/representative/tree_periods.jl
@@ -23,11 +23,11 @@ _rper(rp::StratNodeReprPeriod) = rp.rp
 
 mult_strat(rp::StratNodeReprPeriod) = rp.mult_sp
 mult_repr(rp::StratNodeReprPeriod) = rp.mult_rp
-probability_branch(rp::StratNodeReprPeriod) = rp.prob_branch
-probability(rp::StratNodeReprPeriod) = rp.prob_branch
 function multiple(rp::StratNodeReprPeriod, t::OperationalPeriod)
     return t.multiple / rp.mult_sp
 end
+probability_branch(rp::StratNodeReprPeriod) = rp.prob_branch
+probability(rp::StratNodeReprPeriod) = rp.prob_branch
 
 StrategicTreeIndexable(::Type{<:StratNodeReprPeriod}) = HasStratTreeIndex()
 StrategicIndexable(::Type{<:StratNodeReprPeriod}) = HasStratIndex()
@@ -48,17 +48,17 @@ end
 Base.eltype(_::StratNodeReprPeriod{T,OP}) where {T,OP} = TreePeriod{eltype(op)}
 
 """
-    struct StratNodeReprPeriods <: AbstractTreeStructure
+    struct StratNodeReprPeriods{T,OP<:TimeStructInnerIter{T}} <: AbstractTreeStructure{T}
 
 Type for iterating through the individual presentative periods of a [`StratNode`](@ref).
 It is automatically created through the function [`repr_periods`](@ref).
 """
-struct StratNodeReprPeriods <: AbstractTreeStructure
+struct StratNodeReprPeriods{T,OP<:TimeStructInnerIter{T}} <: AbstractTreeStructure{T}
     sp::Int
     branch::Int
     mult_sp::Float64
     prob_branch::Float64
-    repr::Any
+    repr::OP
 end
 
 _strat_per(rps::StratNodeReprPeriods) = rps.sp

--- a/src/representative/tree_periods.jl
+++ b/src/representative/tree_periods.jl
@@ -2,7 +2,7 @@
     struct StratNodeReprPeriod{T,OP<:TimeStructure{T}} <: AbstractRepresentativePeriod{T}
 
 A structure representing a single representative period of a [`StratNode`](@ref) of a
-[`TwoLevelTree`](@ref). It is created through iterating through [`StratNodeReprPeriods`](@ref).
+[`TwoLevelTree`](@ref). It is created through iterating through [`StratNodeReprPers`](@ref).
 
 It is equivalent to a [`StratReprPeriod`](@ref) of a [`TwoLevel`](@ref) time structure when
 utilizing a [`TwoLevelTree`](@ref).
@@ -48,12 +48,12 @@ end
 Base.eltype(_::StratNodeReprPeriod{T,OP}) where {T,OP} = TreePeriod{eltype(op)}
 
 """
-    struct StratNodeReprPeriods{T,OP<:TimeStructInnerIter{T}} <: AbstractTreeStructure{T}
+    struct StratNodeReprPers{T,OP<:TimeStructInnerIter{T}} <: AbstractTreeStructure{T}
 
 Type for iterating through the individual presentative periods of a [`StratNode`](@ref).
 It is automatically created through the function [`repr_periods`](@ref).
 """
-struct StratNodeReprPeriods{T,OP<:TimeStructInnerIter{T}} <: AbstractTreeStructure{T}
+struct StratNodeReprPers{T,OP<:TimeStructInnerIter{T}} <: AbstractTreeStructure{T}
     sp::Int
     branch::Int
     mult_sp::Float64
@@ -61,20 +61,20 @@ struct StratNodeReprPeriods{T,OP<:TimeStructInnerIter{T}} <: AbstractTreeStructu
     repr::OP
 end
 
-_strat_per(rps::StratNodeReprPeriods) = rps.sp
-_branch(rps::StratNodeReprPeriods) = rps.branch
+_strat_per(rps::StratNodeReprPers) = rps.sp
+_branch(rps::StratNodeReprPers) = rps.branch
 
-mult_strat(rps::StratNodeReprPeriods) = rps.mult_sp
-probability_branch(rps::StratNodeReprPeriods) = rps.prob_branch
+mult_strat(rps::StratNodeReprPers) = rps.mult_sp
+probability_branch(rps::StratNodeReprPers) = rps.prob_branch
 
-_oper_struct(rps::StratNodeReprPeriods) = rps.repr
+_oper_struct(rps::StratNodeReprPers) = rps.repr
 
 """
 When the `TimeStructure` is a [`StratNode`](@ref), `repr_periods` returns the iterator
-[`StratNodeReprPeriods`](@ref).
+[`StratNodeReprPers`](@ref).
 """
 function repr_periods(n::StratNode{S,T,OP}) where {S,T,OP<:TimeStructure{T}}
-    return StratNodeReprPeriods(
+    return StratNodeReprPers(
         _strat_per(n),
         _branch(n),
         mult_strat(n),
@@ -83,7 +83,7 @@ function repr_periods(n::StratNode{S,T,OP}) where {S,T,OP<:TimeStructure{T}}
     )
 end
 
-function strat_node_period(rps::StratNodeReprPeriods, next, state)
+function strat_node_period(rps::StratNodeReprPers, next, state)
     return StratNodeReprPeriod(
         _strat_per(rps),
         _branch(rps),
@@ -95,7 +95,7 @@ function strat_node_period(rps::StratNodeReprPeriods, next, state)
     )
 end
 
-Base.eltype(_::StratNodeReprPeriods) = StratNodeReprPeriod
+Base.eltype(_::StratNodeReprPers) = StratNodeReprPeriod
 
 """
 When the `TimeStructure` is a [`TwoLevelTree`](@ref), `repr_periods` returns an `Array` of

--- a/src/representative/tree_periods.jl
+++ b/src/representative/tree_periods.jl
@@ -45,7 +45,7 @@ end
 function Base.show(io::IO, rp::StratNodeReprPeriod)
     return print(io, "sp$(_strat_per(rp))-br$(_branch(rp))-rp$(_rper(rp))")
 end
-Base.eltype(_::StratNodeReprPeriod) = TreePeriod
+Base.eltype(_::StratNodeReprPeriod{T,OP}) where {T,OP} = TreePeriod{eltype(op)}
 
 """
     struct StratNodeReprPeriods <: AbstractTreeStructure

--- a/src/strat_scenarios/core_types.jl
+++ b/src/strat_scenarios/core_types.jl
@@ -240,7 +240,7 @@ function regular_tree(
 end
 
 """
-    struct StratTreeNodes{S, T, OP} <: AbstractTreeStructure
+    struct StratTreeNodes{S,T,OP<:TimeStructure{T}} <: AbstractTreeStructure{T}
 
 Type for iterating through the individual strategic nodes of a [`TwoLevelTree`](@ref).
 It is automatically created through the function [`strat_periods`](@ref), and hence,
@@ -249,7 +249,7 @@ It is automatically created through the function [`strat_periods`](@ref), and he
 Iterating through `StratTreeNodes` using the `WithPrev` iterator changes the behaviour,
 although the meaning remains unchanged.
 """
-struct StratTreeNodes{S,T,OP} <: AbstractTreeStructure
+struct StratTreeNodes{S,T,OP<:TimeStructure{T}} <: AbstractTreeStructure{T}
     ts::TwoLevelTree{S,T,OP}
 end
 

--- a/src/strat_scenarios/core_types.jl
+++ b/src/strat_scenarios/core_types.jl
@@ -75,25 +75,25 @@ struct TreePeriod{P} <: TimePeriod where {P<:TimePeriod}
     multiple::Float64
     period::P
 end
+_period(t::TreePeriod) = t.period
 
 _strat_per(t::TreePeriod) = t.sp
 _branch(t::TreePeriod) = t.branch
+_rper(t::TreePeriod) = _rper(_period(t))
+_opscen(t::TreePeriod) = _opscen(_period(t))
+_oper(t::TreePeriod) = _oper(_period(t))
 
-_rper(t::TreePeriod) = _rper(t.period)
-_opscen(t::TreePeriod) = _opscen(t.period)
-_oper(t::TreePeriod) = _oper(t.period)
-
-isfirst(t::TreePeriod) = isfirst(t.period)
-duration(t::TreePeriod) = duration(t.period)
+isfirst(t::TreePeriod) = isfirst(_period(t))
+duration(t::TreePeriod) = duration(_period(t))
 multiple(t::TreePeriod) = t.multiple
 probability_branch(t::TreePeriod) = t.prob_branch
-probability(t::TreePeriod) = probability(t.period) * probability_branch(t)
+probability(t::TreePeriod) = probability(_period(t)) * probability_branch(t)
 
 function Base.show(io::IO, t::TreePeriod)
-    return print(io, "sp$(t.sp)-br$(t.branch)-$(t.period)")
+    return print(io, "sp$(_strat_per(t))-br$(_branch(t))-$(_period(t))")
 end
 function Base.isless(t1::TreePeriod, t2::TreePeriod)
-    return t1.period < t2.period
+    return _strat_per(t1) < _strat_per(t2) || (_strat_per(t1) == _strat_per(t2) && _period(t1) < _period(t2))
 end
 
 # Convenient constructors for the individual types

--- a/src/strat_scenarios/core_types.jl
+++ b/src/strat_scenarios/core_types.jl
@@ -93,7 +93,8 @@ function Base.show(io::IO, t::TreePeriod)
     return print(io, "sp$(_strat_per(t))-br$(_branch(t))-$(_period(t))")
 end
 function Base.isless(t1::TreePeriod, t2::TreePeriod)
-    return _strat_per(t1) < _strat_per(t2) || (_strat_per(t1) == _strat_per(t2) && _period(t1) < _period(t2))
+    return _strat_per(t1) < _strat_per(t2) ||
+           (_strat_per(t1) == _strat_per(t2) && _period(t1) < _period(t2))
 end
 
 # Convenient constructors for the individual types

--- a/src/strat_scenarios/core_types.jl
+++ b/src/strat_scenarios/core_types.jl
@@ -71,9 +71,9 @@ respective branch and probability of the branch
 struct TreePeriod{P} <: TimePeriod where {P<:TimePeriod}
     sp::Int
     branch::Int
-    prob_branch::Float64
-    multiple::Float64
     period::P
+    multiple::Float64
+    prob_branch::Float64
 end
 _period(t::TreePeriod) = t.period
 
@@ -97,9 +97,9 @@ function Base.isless(t1::TreePeriod, t2::TreePeriod)
 end
 
 # Convenient constructors for the individual types
-function TreePeriod(n::StratNode, per::P) where {P<:Union{TimePeriod,TimeStructure}}
+function TreePeriod(n::StratNode, per::TimePeriod)
     mult = n.mult_sp * multiple(per)
-    return TreePeriod(_strat_per(n), _branch(n), probability_branch(n), mult, per)
+    return TreePeriod(_strat_per(n), _branch(n), per, mult, probability_branch(n))
 end
 """
     struct StrategicScenario
@@ -198,8 +198,8 @@ function add_node(
         sp,
         branches(tree, sp) + 1,
         duration,
-        prob_branch,
         mult_sp,
+        prob_branch,
         parent,
         oper,
     )

--- a/src/strat_scenarios/tree_periods.jl
+++ b/src/strat_scenarios/tree_periods.jl
@@ -1,16 +1,16 @@
 """
-    AbstractTreeNode{S,T} <: AbstractStrategicPeriod{S,T}
+    abstract type AbstractTreeNode{S,T} <: AbstractStrategicPeriod{S,T}
 
 Abstract base type for all tree nodes within a [`TwoLevelTree`](@ref) type.
 """
 abstract type AbstractTreeNode{S,T} <: AbstractStrategicPeriod{S,T} end
 
 """
-    AbstractTreeStructure
+    abstract type AbstractTreeStructure{T} <: TimeStructOuterIter{T}
 
 Abstract base type for all tree timestructures within a [`TwoLevelTree`](@ref) type.
 """
-abstract type AbstractTreeStructure end
+abstract type AbstractTreeStructure{T} <: TimeStructOuterIter{T} end
 
 Base.length(ats::AbstractTreeStructure) = length(_oper_struct(ats))
 function Base.iterate(ats::AbstractTreeStructure, state = (nothing, 1))

--- a/src/strat_scenarios/tree_periods.jl
+++ b/src/strat_scenarios/tree_periods.jl
@@ -43,8 +43,8 @@ struct StratNode{S,T,OP<:TimeStructure{T}} <: AbstractTreeNode{S,T}
     sp::Int
     branch::Int
     duration::S
-    prob_branch::Float64
     mult_sp::Float64
+    prob_branch::Float64
     parent::Any
     operational::OP
 end

--- a/src/strategic/core_types.jl
+++ b/src/strategic/core_types.jl
@@ -214,7 +214,8 @@ function Base.show(io::IO, t::OperationalPeriod)
     return print(io, "sp$(_strat_per(t))-$(_period(t))")
 end
 function Base.isless(t1::OperationalPeriod, t2::OperationalPeriod)
-    return _strat_per(t1) < _strat_per(t2) || (_strat_per(t1) == _strat_per(t2) && _period(t1) < _period(t2))
+    return _strat_per(t1) < _strat_per(t2) ||
+           (_strat_per(t1) == _strat_per(t2) && _period(t1) < _period(t2))
 end
 
 # Convenience constructor for the type

--- a/src/strategic/core_types.jl
+++ b/src/strategic/core_types.jl
@@ -167,7 +167,7 @@ end
 function Base.length(ts::TwoLevel)
     return sum(length(op) for op in ts.operational)
 end
-Base.eltype(::Type{TwoLevel{S,T,OP}}) where {S,T,OP} = OperationalPeriod
+Base.eltype(::Type{TwoLevel{S,T,OP}}) where {S,T,OP} = OperationalPeriod{eltype(OP)}
 function Base.iterate(ts::TwoLevel, state = (nothing, 1))
     sp = state[2]
     next =
@@ -188,32 +188,33 @@ function Base.last(ts::TwoLevel)
 end
 
 """
-	struct OperationalPeriod <: TimePeriod
+	struct OperationalPeriod{P} <: TimePeriod where {P<:TimePeriod}
 
 Time period for a single operational period. It is created through iterating through a
 [`TwoLevel`](@ref) time structure.
 """
-struct OperationalPeriod <: TimePeriod
+struct OperationalPeriod{P} <: TimePeriod where {P<:TimePeriod}
     sp::Int
-    period::TimePeriod
+    period::P
     multiple::Float64
 end
+_period(t::OperationalPeriod) = t.period
 
-_oper(t::OperationalPeriod) = _oper(t.period)
-_opscen(t::OperationalPeriod) = _opscen(t.period)
-_rper(t::OperationalPeriod) = _rper(t.period)
 _strat_per(t::OperationalPeriod) = t.sp
+_rper(t::OperationalPeriod) = _rper(_period(t))
+_opscen(t::OperationalPeriod) = _opscen(_period(t))
+_oper(t::OperationalPeriod) = _oper(_period(t))
 
-isfirst(t::OperationalPeriod) = isfirst(t.period)
-duration(t::OperationalPeriod) = duration(t.period)
+isfirst(t::OperationalPeriod) = isfirst(_period(t))
+duration(t::OperationalPeriod) = duration(_period(t))
 multiple(t::OperationalPeriod) = t.multiple
-probability(t::OperationalPeriod) = probability(t.period)
+probability(t::OperationalPeriod) = probability(_period(t))
 
 function Base.show(io::IO, t::OperationalPeriod)
-    return print(io, "sp$(t.sp)-$(t.period)")
+    return print(io, "sp$(_strat_per(t))-$(_period(t))")
 end
 function Base.isless(t1::OperationalPeriod, t2::OperationalPeriod)
-    return t1.sp < t2.sp || (t1.sp == t2.sp && t1.period < t2.period)
+    return _strat_per(t1) < _strat_per(t2) || (_strat_per(t1) == _strat_per(t2) && _period(t1) < _period(t2))
 end
 
 # Convenience constructor for the type

--- a/src/strategic/strat_periods.jl
+++ b/src/strategic/strat_periods.jl
@@ -181,7 +181,7 @@ Type for iterating through the individual strategic periods of a
 [`TwoLevel`](@ref) time structure. It is automatically created through the
 function [`strat_periods`](@ref).
 """
-struct StratPers{S,T,OP} <:TimeStructInnerIter{T}
+struct StratPers{S,T,OP} <: TimeStructInnerIter{T}
     ts::TwoLevel{S,T,OP}
 end
 

--- a/src/strategic/strat_periods.jl
+++ b/src/strategic/strat_periods.jl
@@ -114,7 +114,7 @@ Base.last(sps::SingleStrategicPeriodWrapper) = SingleStrategicPeriod(_oper_struc
     struct StrategicPeriod{S,T,OP<:TimeStructure{T}} <: AbstractStrategicPeriod{S,T}
 
 A type representing a single strategic period supporting iteration over its
-time periods. It is created when iterating through [`StratPeriods`](@ref).
+time periods. It is created when iterating through [`StratPers`](@ref).
 """
 struct StrategicPeriod{S,T,OP<:TimeStructure{T}} <: AbstractStrategicPeriod{S,T}
     sp::Int
@@ -175,25 +175,25 @@ end
 multiple_strat(sp::StrategicPeriod, t) = multiple(t) / duration_strat(sp)
 
 """
-    struct StratPeriods{S,T,OP} <:TimeStructInnerIter{T}
+    struct StratPers{S,T,OP} <:TimeStructInnerIter{T}
 
 Type for iterating through the individual strategic periods of a
 [`TwoLevel`](@ref) time structure. It is automatically created through the
 function [`strat_periods`](@ref).
 """
-struct StratPeriods{S,T,OP} <:TimeStructInnerIter{T}
+struct StratPers{S,T,OP} <:TimeStructInnerIter{T}
     ts::TwoLevel{S,T,OP}
 end
 
-_oper_struct(sps::StratPeriods) = sps.ts
+_oper_struct(sps::StratPers) = sps.ts
 
-function remaining(sp::AbstractStrategicPeriod, sps::StratPeriods)
+function remaining(sp::AbstractStrategicPeriod, sps::StratPers)
     return sum(duration_strat(spp) for spp in sps if spp >= sp)
 end
 
 """
 When the `TimeStructure` is a [`TwoLevel`](@ref), `strat_periods` returns the
-iterator [`StratPeriods`](@ref).
+iterator [`StratPers`](@ref).
 
 ## Example
 ```julia
@@ -201,10 +201,10 @@ periods = TwoLevel(5, SimpleTimes(10,1))
 total_dur = sum(duration_strat(sp) for sp in strategic_periods(periods))
 ```
 """
-strat_periods(ts::TwoLevel) = StratPeriods(ts)
+strat_periods(ts::TwoLevel) = StratPers(ts)
 
 # Provide a constructor to simplify the design
-function StrategicPeriod(sps::StratPeriods, sp::Int)
+function StrategicPeriod(sps::StratPers, sp::Int)
     return StrategicPeriod(
         sp,
         _oper_struct(sps).duration[sp],
@@ -214,22 +214,22 @@ function StrategicPeriod(sps::StratPeriods, sp::Int)
 end
 
 # Add basic functions of iterators
-Base.length(sps::StratPeriods) = _oper_struct(sps).len
-function Base.eltype(_::StratPeriods{S,T,OP}) where {S,T,OP<:TimeStructure{T}}
+Base.length(sps::StratPers) = _oper_struct(sps).len
+function Base.eltype(_::StratPers{S,T,OP}) where {S,T,OP<:TimeStructure{T}}
     return StrategicPeriod{S,T,OP}
 end
-function Base.iterate(sps::StratPeriods, state = nothing)
+function Base.iterate(sps::StratPers, state = nothing)
     sp = isnothing(state) ? 1 : state + 1
     sp > length(sps) && return nothing
 
     return StrategicPeriod(sps, sp), sp
 end
-function Base.getindex(sps::StratPeriods, index::Int)
+function Base.getindex(sps::StratPers, index::Int)
     return StrategicPeriod(sps, index)
 end
-function Base.eachindex(sps::StratPeriods)
+function Base.eachindex(sps::StratPers)
     return eachindex(_oper_struct(sps).rep_periods)
 end
-function Base.last(sps::StratPeriods)
+function Base.last(sps::StratPers)
     return StrategicPeriod(sps, length(sps))
 end

--- a/src/strategic/strat_periods.jl
+++ b/src/strategic/strat_periods.jl
@@ -136,7 +136,7 @@ end
 # Add basic functions of iterators
 Base.length(sp::StrategicPeriod) = length(sp.operational)
 function Base.eltype(_::Type{StrategicPeriod{S,T,OP}}) where {S,T,OP}
-    return OperationalPeriod
+    return OperationalPeriod{eltype(OP)}
 end
 function Base.iterate(sp::StrategicPeriod, state = nothing)
     next = isnothing(state) ? iterate(sp.operational) : iterate(sp.operational, state)

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -2,13 +2,43 @@
 Duration = Number
 
 """
-    abstract type TimeStructure{T}
+    abstract type TimeStructure{T<:Duration}
 
 Abstract type representing different time structures that
 consists of one or more time periods. The type 'T' gives
 the data type used for the duration of the time periods.
 """
 abstract type TimeStructure{T<:Duration} end
+
+"""
+    abstract type TimeStructInnerIter{T<:Duration}
+
+Abstract type representing different iterators for individual time structures.
+The difference to [`TimeStructure`](@ref) is that iterating through a `TimeStructInnerIter`
+will not provide a [`TimePeriod`](@ref), but a [`TimeStructure`](@ref).
+
+!!! note
+    `TimeStructInnerIter` and [`TimeStructOuterIter`](@ref) are comparable. The
+    former is implemented for the inner level, that is if you want to use, _e.g.,
+    `opscenarios(OperationalScenarios())` while the latter is used for the outer level,
+    _e.g._, `opscenarios(StrategicPeriod())`.
+"""
+abstract type TimeStructInnerIter{T<:Duration} end
+
+"""
+    abstract type TimeStructOuterIter{T<:Duration}
+
+Abstract type representing different iterators for individual time structures.
+The difference to [`TimeStructure`](@ref) is that iterating through a `TimeStructOuterIter`
+will not provide a [`TimePeriod`](@ref), but a [`TimeStructure`](@ref).
+
+!!! note
+    [`TimeStructInnerIter`](@ref) and `TimeStructOuterIter` are comparable. The
+    former is implemented for the inner level, that is if you want to use, _e.g.,
+    `opscenarios(OperationalScenarios())` while the latter is used for the outer level,
+    _e.g._, `opscenarios(StrategicPeriod())`.
+"""
+abstract type TimeStructOuterIter{T<:Duration} end
 
 """
     abstract type TimePeriod

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -19,7 +19,7 @@ will not provide a [`TimePeriod`](@ref), but a [`TimeStructure`](@ref).
 
 !!! note
     `TimeStructInnerIter` and [`TimeStructOuterIter`](@ref) are comparable. The
-    former is implemented for the inner level, that is if you want to use, _e.g.,
+    former is implemented for the inner level, that is if you want to use, _e.g._,
     `opscenarios(OperationalScenarios())` while the latter is used for the outer level,
     _e.g._, `opscenarios(StrategicPeriod())`.
 """
@@ -34,7 +34,7 @@ will not provide a [`TimePeriod`](@ref), but a [`TimeStructure`](@ref).
 
 !!! note
     [`TimeStructInnerIter`](@ref) and `TimeStructOuterIter` are comparable. The
-    former is implemented for the inner level, that is if you want to use, _e.g.,
+    former is implemented for the inner level, that is if you want to use, _e.g._,
     `opscenarios(OperationalScenarios())` while the latter is used for the outer level,
     _e.g._, `opscenarios(StrategicPeriod())`.
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -135,8 +135,7 @@ function expand_dataframe!(df, periods) end
 
 # All introduced subtypes require the same procedures for the iteration and indexing.
 # Hence, all introduced types use the same functions.
-TreeStructure =
-    Union{StratNodeOpScenario,StratNodeReprPeriod,StratNodeReprOpScenario}
+TreeStructure = Union{StratNodeOpScenario,StratNodeReprPeriod,StratNodeReprOpScenario}
 Base.length(ts::TreeStructure) = length(ts.operational)
 function Base.last(ts::TreeStructure)
     per = last(ts.operational)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -136,7 +136,7 @@ function expand_dataframe!(df, periods) end
 # All introduced subtypes require the same procedures for the iteration and indexing.
 # Hence, all introduced types use the same functions.
 TreeStructure =
-    Union{StratNodeOperationalScenario,StratNodeReprPeriod,StratNodeReprOpScenario}
+    Union{StratNodeOpScenario,StratNodeReprPeriod,StratNodeReprOpScenario}
 Base.length(ts::TreeStructure) = length(ts.operational)
 function Base.last(ts::TreeStructure)
     per = last(ts.operational)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -116,7 +116,7 @@ end
     week = SimpleTimes(168, 1)
     ts = OperationalScenarios(3, [day, day, week], [0.1, 0.2, 0.7])
 
-    @test first(ts) == TimeStruct.ScenarioPeriod(1, 0.1, 7.0, TimeStruct.SimplePeriod(1, 1))
+    @test first(ts) == TimeStruct.ScenarioPeriod(1, TimeStruct.SimplePeriod(1, 1), 7.0, 0.1)
     @test length(ts) == 216
     pers = []
     for sc in opscenarios(ts)
@@ -133,7 +133,7 @@ end
     # resolution and the same probability of occuring
     ts = OperationalScenarios([day, week])
 
-    @test first(ts) == TimeStruct.ScenarioPeriod(1, 0.5, 7.0, TimeStruct.SimplePeriod(1, 1))
+    @test first(ts) == TimeStruct.ScenarioPeriod(1, TimeStruct.SimplePeriod(1, 1), 7.0, 0.5)
     @test length(ts) == 192
 
     scens = opscenarios(ts)
@@ -477,7 +477,7 @@ end
     ops = collect(seasonal_year)
     @test ops[1] == TimeStruct.OperationalPeriod(
         1,
-        TimeStruct.ScenarioPeriod(1, 0.1, 7.0, TimeStruct.SimplePeriod(1, 1)),
+        TimeStruct.ScenarioPeriod(1, TimeStruct.SimplePeriod(1, 1), 7.0, 0.1),
         91.0,
     )
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -524,7 +524,7 @@ end
     sp = first(strat_periods(ts))
     scen = first(opscenarios(sp))
     @test length(scen) == 10
-    @test eltype(typeof(scen)) == TimeStruct.OperationalPeriod
+    @test eltype(typeof(scen)) == TimeStruct.OperationalPeriod{TimeStruct.SimplePeriod{Int}}
     @test repr(scen) == "sp1-sc1"
     @test probability(scen) == 1.0
     per = first(scen)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -189,7 +189,7 @@ end
     @test rps[1] < rps[2]
     @test rps[1] < rps[25]
 
-    # Test of direct functions of `ReprPeriods`
+    # Test of direct functions of `ReprPers`
     rpers = repr_periods(rep)
     @test eltype(rpers) == TimeStruct.RepresentativePeriod{Int,SimpleTimes{Int}}
     @test last(rpers) == collect(rpers)[end]


### PR DESCRIPTION
This PR closes #27 . All individual points are addressed for a consistent structure. From this PR, we can see that a lot of iteration utilities can be reused nowadays, although I have not yet implemented these, except for `TreeNodes`.

The naming changes lead to breaking changes for `EnergyModelsInvestments`, as we previously used (unnecessary) dispatch on `StratPeriods`.