### PR TITLE
Remove unused version of multiple

### DIFF
--- a/src/representative/strat_periods.jl
+++ b/src/representative/strat_periods.jl
@@ -17,7 +17,6 @@ _rper(rp::StratReprPeriod) = rp.rp
 
 mult_strat(rp::StratReprPeriod) = rp.mult_sp
 mult_repr(rp::StratReprPeriod) = rp.mult_rp
-multiple(rp::StratReprPeriod, t::OperationalPeriod) = t.multiple / rp.mult_sp
 
 StrategicIndexable(::Type{<:StratReprPeriod}) = HasStratIndex()
 

--- a/src/representative/tree_periods.jl
+++ b/src/representative/tree_periods.jl
@@ -23,9 +23,7 @@ _rper(rp::StratNodeReprPeriod) = rp.rp
 
 mult_strat(rp::StratNodeReprPeriod) = rp.mult_sp
 mult_repr(rp::StratNodeReprPeriod) = rp.mult_rp
-function multiple(rp::StratNodeReprPeriod, t::OperationalPeriod)
-    return t.multiple / rp.mult_sp
-end
+
 probability_branch(rp::StratNodeReprPeriod) = rp.prob_branch
 probability(rp::StratNodeReprPeriod) = rp.prob_branch
 

--- a/src/structures.jl
+++ b/src/structures.jl
@@ -101,5 +101,3 @@ _total_duration(tss::Vector) = sum(duration(ts) for ts in tss)
 _multiple_adj(ts::TimeStructure, per) = 1.0
 
 stripunit(val) = val
-
-multiple(ts::TimeStructure, t::TimePeriod) = 1.0


### PR DESCRIPTION
This version of `multiple` with two input arguments is leftovers from some earlier experimentation and should be removed at this stage.