### PR TITLE
Introduced AbstractStratPers as new supertype

### DIFF
--- a/docs/src/reference/internal.md
+++ b/docs/src/reference/internal.md
@@ -39,6 +39,7 @@ TimeStruct.StrategicPeriod
 ### Iterator types
 
 ```@docs
+TimeStruct.AbstractStratPers
 TimeStruct.SingleStrategicPeriodWrapper
 TimeStruct.StratPers
 ```

--- a/src/strat_scenarios/core_types.jl
+++ b/src/strat_scenarios/core_types.jl
@@ -241,7 +241,7 @@ function regular_tree(
 end
 
 """
-    struct StratTreeNodes{S,T,OP<:TimeStructure{T}} <: AbstractTreeStructure{T}
+    struct StratTreeNodes{S,T,OP<:TimeStructure{T}} <: AbstractStratPers{T}
 
 Type for iterating through the individual strategic nodes of a [`TwoLevelTree`](@ref).
 It is automatically created through the function [`strat_periods`](@ref), and hence,
@@ -250,17 +250,20 @@ It is automatically created through the function [`strat_periods`](@ref), and he
 Iterating through `StratTreeNodes` using the `WithPrev` iterator changes the behaviour,
 although the meaning remains unchanged.
 """
-struct StratTreeNodes{S,T,OP<:TimeStructure{T}} <: AbstractTreeStructure{T}
+struct StratTreeNodes{S,T,OP<:TimeStructure{T}} <: AbstractStratPers{T}
     ts::TwoLevelTree{S,T,OP}
 end
 
 # Adding methods to existing Julia functions
 Base.length(sps::StratTreeNodes) = length(sps.ts.nodes)
-Base.eltype(_::Type{StratTreeNodes{T,OP}}) where {T,OP} = OP
+Base.eltype(_::Type{StratTreeNodes{S,T,OP}}) where {S,T,OP} = OP
 function Base.iterate(stps::StratTreeNodes, state = nothing)
     next = isnothing(state) ? 1 : state + 1
     next == length(stps) + 1 && return nothing
     return stps.ts.nodes[next], next
+end
+function Base.getindex(sps::StratTreeNodes, index::Int)
+    return sps.ts.nodes[index]
 end
 
 """

--- a/src/strategic/strat_periods.jl
+++ b/src/strategic/strat_periods.jl
@@ -6,6 +6,13 @@ These periods are obtained when iterating through the strategic periods of a tim
 structure declared by the function [`strat_periods`](@ref).
 """
 abstract type AbstractStrategicPeriod{S,T} <: TimeStructurePeriod{T} end
+"""
+    abstract type AbstractStratPers{S,T} <: TimeStructInnerIter
+
+Abstract type used for time structures that represent a collection of strategic periods,
+obtained through calling the function [`strat_periods`](@ref).
+"""
+abstract type AbstractStratPers{T} <: TimeStructInnerIter{T} end
 
 function _strat_per(sp::AbstractStrategicPeriod)
     return error("_strat_per() not implemented for $(typeof(sp))")
@@ -77,13 +84,13 @@ end
 Base.last(sp::SingleStrategicPeriod) = last(sp.ts)
 
 """
-    struct SingleStrategicPeriodWrapper{T,SP<:TimeStructure{T}} <: TimeStructInnerIter{T}
+    struct SingleStrategicPeriodWrapper{T,SP<:TimeStructure{T}} <: AbstractStratPers{T}
 
 Type for iterating through the individual strategic periods of a time structure
 without [`TwoLevel`](@ref). It is automatically created through the function
 [`strat_periods`](@ref).
 """
-struct SingleStrategicPeriodWrapper{T,SP<:TimeStructure{T}} <: TimeStructInnerIter{T}
+struct SingleStrategicPeriodWrapper{T,SP<:TimeStructure{T}} <: AbstractStratPers{T}
     ts::SP
 end
 
@@ -184,13 +191,13 @@ end
 multiple_strat(sp::StrategicPeriod, t) = multiple(t) / duration_strat(sp)
 
 """
-    struct StratPers{S,T,OP} <:TimeStructInnerIter{T}
+    struct StratPers{S,T,OP} <: AbstractStratPers{T}
 
 Type for iterating through the individual strategic periods of a
 [`TwoLevel`](@ref) time structure. It is automatically created through the
 function [`strat_periods`](@ref).
 """
-struct StratPers{S,T,OP} <: TimeStructInnerIter{T}
+struct StratPers{S,T,OP} <: AbstractStratPers{T}
     ts::TwoLevel{S,T,OP}
 end
 
@@ -237,7 +244,7 @@ function Base.getindex(sps::StratPers, index::Int)
     return StrategicPeriod(sps, index)
 end
 function Base.eachindex(sps::StratPers)
-    return eachindex(_oper_struct(sps).rep_periods)
+    return eachindex(_oper_struct(sps).operational)
 end
 function Base.last(sps::StratPers)
     return StrategicPeriod(sps, length(sps))


### PR DESCRIPTION
The introduction of the abstract supertype `AbstractStratPers` allows the user to simplify dispatch on `StratPers` from `TwoLevel` and `TwoLevelTree`.

In general, it can be beneficial to use the same approach for `RepPers` and `OpScens`. In this case, we however have to consider how we handle `TimeStructInnerIter` and `TimeStructInnerOuter`. It can be seen as an extension to remove unnecessary code.

Additionally, I fixed a minor bug I ran aground regarding `eachindex(StratPers)`.