### PR TITLE
Restructure discount and fix error

### DIFF
--- a/src/discount.jl
+++ b/src/discount.jl
@@ -47,7 +47,6 @@ end
 
 _start_strat(t::TimePeriod, ts::TimeStructure) = _start_strat(_sp_period(t, ts), ts)
 
-
 function _to_year(start, timeunit_to_year)
     return start * timeunit_to_year
 end

--- a/src/discount.jl
+++ b/src/discount.jl
@@ -19,7 +19,7 @@ end
 
 function _start_strat(sp::StratNode, ts::TwoLevelTree{S}) where {S}
     start = zero(S)
-    node = sp
+    node = _parent(sp)
     while !isnothing(node)
         start += duration_strat(node)
         node = _parent(node)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1277,6 +1277,31 @@ end
 
     @test sum(objective_weight(sp, disc) for sp in strat_periods(periods_unit)) ≈ 8.435 atol =
         1e-3
+
+    simple = SimpleTimes(10, 2)
+    for sp in strat_periods(simple)
+        for t in sp
+            @test discount(sp, simple, 0.05) == discount(t, simple, 0.05)
+            @test discount(sp, simple, 0.05; type = "avg") == discount(t, simple, 0.05; type = "avg")
+        end
+    end
+
+    for sp in strat_periods(periods)
+        for t in sp
+            @test discount(sp, periods, 0.05) == discount(t, periods, 0.05)
+            @test discount(sp, periods, 0.05; type = "avg") == discount(t, periods, 0.05; type = "avg")
+        end
+    end
+
+    tree = regular_tree(5, [2, 3], SimpleTimes(7, 1); op_per_strat = 365)
+    for sp in strat_periods(tree)
+        for t in sp
+            @test discount(sp, tree, 0.05) == discount(t, tree, 0.05)
+            @test discount(sp, tree, 0.05; type = "avg") == discount(t, tree, 0.05; type = "avg")
+        end
+    end
+
+
 end
 
 @testitem "Start and end times" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1282,14 +1282,16 @@ end
     for sp in strat_periods(simple)
         for t in sp
             @test discount(sp, simple, 0.05) == discount(t, simple, 0.05)
-            @test discount(sp, simple, 0.05; type = "avg") == discount(t, simple, 0.05; type = "avg")
+            @test discount(sp, simple, 0.05; type = "avg") ==
+                  discount(t, simple, 0.05; type = "avg")
         end
     end
 
     for sp in strat_periods(periods)
         for t in sp
             @test discount(sp, periods, 0.05) == discount(t, periods, 0.05)
-            @test discount(sp, periods, 0.05; type = "avg") == discount(t, periods, 0.05; type = "avg")
+            @test discount(sp, periods, 0.05; type = "avg") ==
+                  discount(t, periods, 0.05; type = "avg")
         end
     end
 
@@ -1297,11 +1299,10 @@ end
     for sp in strat_periods(tree)
         for t in sp
             @test discount(sp, tree, 0.05) == discount(t, tree, 0.05)
-            @test discount(sp, tree, 0.05; type = "avg") == discount(t, tree, 0.05; type = "avg")
+            @test discount(sp, tree, 0.05; type = "avg") ==
+                  discount(t, tree, 0.05; type = "avg")
         end
     end
-
-
 end
 
 @testitem "Start and end times" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1288,7 +1288,7 @@ end
     end
 
     uniform_day = SimpleTimes(24, 1)
-    periods = TwoLevel(3, 5, uniform_day, op_per_strat=8760)
+    periods = TwoLevel(3, 5, uniform_day, op_per_strat = 8760)
     for sp in strat_periods(periods)
         for t in sp
             @test discount(sp, periods, 0.05) == discount(t, periods, 0.05)
@@ -1301,8 +1301,8 @@ end
     for sp in strat_periods(tree)
         sp_per = strat_periods(periods)[TimeStruct._strat_per(sp)]
         @test discount(sp, tree, 0.05) == discount(sp_per, periods, 0.05)
-        @test discount(sp, tree, 0.05; type = "avg") == 
-            discount(sp_per, periods, 0.05; type = "avg")
+        @test discount(sp, tree, 0.05; type = "avg") ==
+              discount(sp_per, periods, 0.05; type = "avg")
         for t in sp
             @test discount(sp, tree, 0.05) == discount(t, tree, 0.05)
             @test discount(sp, tree, 0.05; type = "avg") ==

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1287,6 +1287,8 @@ end
         end
     end
 
+    uniform_day = SimpleTimes(24, 1)
+    periods = TwoLevel(3, 5, uniform_day, op_per_strat=8760)
     for sp in strat_periods(periods)
         for t in sp
             @test discount(sp, periods, 0.05) == discount(t, periods, 0.05)
@@ -1297,6 +1299,10 @@ end
 
     tree = regular_tree(5, [2, 3], SimpleTimes(7, 1); op_per_strat = 365)
     for sp in strat_periods(tree)
+        sp_per = strat_periods(periods)[TimeStruct._strat_per(sp)]
+        @test discount(sp, tree, 0.05) == discount(sp_per, periods, 0.05)
+        @test discount(sp, tree, 0.05; type = "avg") == 
+            discount(sp_per, periods, 0.05; type = "avg")
         for t in sp
             @test discount(sp, tree, 0.05) == discount(t, tree, 0.05)
             @test discount(sp, tree, 0.05; type = "avg") ==


### PR DESCRIPTION
This PR has  several purposes:
- allow discounting to work for TwoLevelTree
- allow discounting to work with time structures without strategic periods (e.g. SimpleTimes)
- correct an error when calculating average discount for an operational period