### PR TITLE
Initial tests with a Makie extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,15 +9,18 @@ TimeZones = "f269a46b-ccf7-5d73-abea-4c690281aa53"
 
 [weakdeps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [extensions]
 TimeStructDataFramesExt = "DataFrames"
+TimeStructMakieExt = "Makie"
 TimeStructUnitfulExt = "Unitful"
 
 [compat]
 DataFrames = "1"
 Dates = "1"
+Makie = "0.21"
 TimeZones = "1"
 Unitful = "1"
 julia = "^1.9"

--- a/ext/TimeStructMakieExt.jl
+++ b/ext/TimeStructMakieExt.jl
@@ -1,0 +1,43 @@
+module TimeStructMakieExt
+using Makie
+using TimeStruct
+import TimeStruct: profilechart, profilechart!
+
+function Makie.convert_arguments(P::PointBased, periods, profile::TimeProfile)
+    pts = [Point2(start_oper_time(t, periods), profile[t]) for t in periods]
+    l = last(periods)
+    push!(pts, Point2(end_oper_time(l, periods), profile[l]))
+    return (pts,)
+end
+
+@recipe(ProfileChart) do scene
+    Attributes(
+        type = :stairs
+    )
+end
+
+function Makie.plot!(sc::ProfileChart{<:Tuple{<:TimeStructure, <:TimeProfile}})
+    periods = sc[1]
+    profile = sc[2]
+
+    for opscen in opscenarios(periods[])
+        stairs!(sc, opscen, profile[]; step = :post)
+    end
+
+    return sc
+end
+
+function Makie.plot(periods::TwoLevel, profile::TimeProfile)
+    fig = Figure()
+    for (i, sp) in enumerate(strat_periods(periods))
+        fig[1, i] = Axis(fig, title = "sp = $sp")
+        for opscen in opscenarios(sp)
+            stairs!(fig[1, i ], opscen, profile; step = :post)
+        end
+    end
+    fig
+end
+
+
+
+end

--- a/src/TimeStruct.jl
+++ b/src/TimeStruct.jl
@@ -58,4 +58,6 @@ export Discounter
 export discount
 export objective_weight
 
+export profilechart
+
 end # module

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -123,9 +123,15 @@ function end_oper_time(t::TimePeriod, ts::OperationalScenarios)
     return end_oper_time(t, ts.scenarios[_opscen(t)])
 end
 
+function end_oper_time(t::TimePeriod, opscen::AbstractOperationalScenario)
+    return end_oper_time(t, opscen.operational)
+end
+
+
 function end_oper_time(t::TimePeriod, ts::TwoLevel)
     return end_oper_time(t, ts.operational[_strat_per(t)])
 end
+
 
 function start_oper_time(t::TimePeriod, ts::TimeStructure)
     return end_oper_time(t, ts) - duration(t)
@@ -155,3 +161,6 @@ function Base.iterate(ts::TreeStructure, state = nothing)
 
     return TreePeriod(ts, next[1]), next[2]
 end
+
+function profilechart end
+function profilechart! end

--- a/test/test_makie.jl
+++ b/test/test_makie.jl
@@ -1,0 +1,20 @@
+using CairoMakie
+using TimeStruct
+
+
+periods = SimpleTimes([1, 2, 4, 2, 3])
+profile = OperationalProfile([2.0, 3.4, 3.5, 1.2, 0.6])
+
+stairs(periods, profile; step = :post)
+scatter!(periods, profile)
+current_figure()
+
+lines(periods, profile)
+
+
+scens = OperationalScenarios(3, periods)
+scen_prof = ScenarioProfile([profile, 0.8 * profile, 1.2 * profile])
+profilechart(scens, scen_prof)
+
+two_level = TwoLevel(3, scens)
+plot(two_level, scen_prof)


### PR DESCRIPTION
This is just some initial testing with a possible Makie extension for plotting profiles (see also issue #16). 

The following is tested and seems to work:
1. A type recipe that handles periods and profiles as input and converts it to 2D points
2. A full recipe that creates a new plot type for profiles
3. Implementing specific plots by defining new methods for Makie.plot()

I guess there is a lot of room for experimenting if we should include this kind of support.  