### PR TITLE
Fixed a bug for multiple_strat

### DIFF
--- a/src/strategic/strat_periods.jl
+++ b/src/strategic/strat_periods.jl
@@ -175,7 +175,7 @@ function Base.last(sp::StrategicPeriod)
 end
 
 """
-    multiple_strat(sp::StrategicPeriod, t)
+    multiple_strat(sp::AbstractStrategicPeriod, t)
 
 Returns the number of times a time period `t` should be accounted for
 when accumulating over one single unit of strategic time.
@@ -188,7 +188,7 @@ for sp in strategic_periods(periods)
 end
 ```
 """
-multiple_strat(sp::StrategicPeriod, t) = multiple(t) / duration_strat(sp)
+multiple_strat(sp::AbstractStrategicPeriod, t) = multiple(t) / duration_strat(sp)
 
 """
     struct StratPers{S,T,OP} <: AbstractStratPers{T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -581,6 +581,8 @@ end
     per = ops2[1]
     @test typeof(per) <: TimeStruct.SimplePeriod
 
+    @test multiple_strat(first(strat_periods(simple)), first(ops1)) == 1/10
+
     ops3 = [t for sc in opscenarios(simple) for t in sc]
     @test ops1 == ops3
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -581,7 +581,7 @@ end
     per = ops2[1]
     @test typeof(per) <: TimeStruct.SimplePeriod
 
-    @test multiple_strat(first(strat_periods(simple)), first(ops1)) == 1/10
+    @test multiple_strat(first(strat_periods(simple)), first(ops1)) == 1 / 10
 
     ops3 = [t for sc in opscenarios(simple) for t in sc]
     @test ops1 == ops3


### PR DESCRIPTION
The function `multiple_strat` was only dispatching on `StrategicPeriod`, not `AbstractStrategicPeriod`. This implies it can lead to issues in which a `SingleStrategicPeriodWrapper` was used.

This is solved with this small fix, which is also tested.