### PR TITLE
Fixed problems coming from dispatching Base.convert

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeStruct"
 uuid = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Truls.Flatberg <Truls.Flatberg@sintef.no>"]
-version = "0.9.3"
+version = "0.9.4"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -34,11 +34,11 @@ function Base.getindex(
     return fp.val
 end
 
-internal_convert(::Type{FixedProfile{T}}, fp::FixedProfile{T}) where {T} = fp
-function internal_convert(::Type{FixedProfile{T}}, fp::FixedProfile{S}) where {T,S}
+_internal_convert(::Type{FixedProfile{T}}, fp::FixedProfile{T}) where {T} = fp
+function _internal_convert(::Type{FixedProfile{T}}, fp::FixedProfile{S}) where {T,S}
     return FixedProfile(convert(T, fp.val))
 end
-function internal_convert(::Type{T}, fp::FixedProfile{S}) where {T,S}
+function _internal_convert(::Type{T}, fp::FixedProfile{S}) where {T,S}
     return FixedProfile(convert(T, fp.val))
 end
 
@@ -79,15 +79,15 @@ function Base.getindex(op::OperationalProfile, i::TimeStructurePeriod)
     return error("Type $(typeof(i)) can not be used as index for an operational profile")
 end
 
-internal_convert(::Type{OperationalProfile{T}}, op::OperationalProfile{T}) where {T} = op
-function internal_convert(
+_internal_convert(::Type{OperationalProfile{T}}, op::OperationalProfile{T}) where {T} = op
+function _internal_convert(
     ::Type{OperationalProfile{T}},
     op::OperationalProfile{S},
 ) where {T,S}
     return OperationalProfile(convert.(T, op.vals))
 end
-internal_convert(::Type{T}, op::OperationalProfile{T}) where {T} = op
-function internal_convert(::Type{T}, op::OperationalProfile{S}) where {T,S}
+_internal_convert(::Type{T}, op::OperationalProfile{T}) where {T} = op
+function _internal_convert(::Type{T}, op::OperationalProfile{S}) where {T,S}
     return OperationalProfile(convert.(T, op.vals))
 end
 
@@ -124,17 +124,17 @@ function StrategicProfile(vals::Vector{T}) where {T}
 end
 function StrategicProfile(vals::Vector{T}) where {T<:TimeProfile}
     ET = promote_type((profilevaluetype(v) for v in vals)...)
-    return StrategicProfile(internal_convert.(ET, vals))
+    return StrategicProfile(_internal_convert.(ET, vals))
 end
-function internal_convert(
+function _internal_convert(
     ::Type{StrategicProfile{T,P}},
     sp::StrategicProfile{T,P},
 ) where {T,P<:TimeProfile{T}}
     return sp
 end
-internal_convert(::Type{T}, sp::StrategicProfile{T}) where {T} = sp
-function internal_convert(::Type{T}, sp::StrategicProfile{S}) where {T,S}
-    return StrategicProfile(internal_convert.(T, sp.vals))
+_internal_convert(::Type{T}, sp::StrategicProfile{T}) where {T} = sp
+function _internal_convert(::Type{T}, sp::StrategicProfile{S}) where {T,S}
+    return StrategicProfile(_internal_convert.(T, sp.vals))
 end
 
 function _value_lookup(::HasStratIndex, sp::StrategicProfile, period)
@@ -177,17 +177,17 @@ end
 
 function ScenarioProfile(vals::Vector{T}) where {T<:TimeProfile}
     ET = promote_type((profilevaluetype(v) for v in vals)...)
-    return ScenarioProfile(internal_convert.(ET, vals))
+    return ScenarioProfile(_internal_convert.(ET, vals))
 end
-function internal_convert(
+function _internal_convert(
     ::Type{ScenarioProfile{T,P}},
     sp::ScenarioProfile{T,P},
 ) where {T,P<:TimeProfile{T}}
     return sp
 end
-internal_convert(::Type{T}, sp::ScenarioProfile{T}) where {T} = sp
-function internal_convert(::Type{T}, sp::ScenarioProfile{S}) where {T,S}
-    return ScenarioProfile(internal_convert.(T, sp.vals))
+_internal_convert(::Type{T}, sp::ScenarioProfile{T}) where {T} = sp
+function _internal_convert(::Type{T}, sp::ScenarioProfile{S}) where {T,S}
+    return ScenarioProfile(_internal_convert.(T, sp.vals))
 end
 
 function ScenarioProfile(vals::Vector{T}) where {T}
@@ -254,17 +254,17 @@ function RepresentativeProfile(vals::Vector{T}) where {T}
 end
 function RepresentativeProfile(vals::Vector{T}) where {T<:TimeProfile}
     ET = promote_type((profilevaluetype(v) for v in vals)...)
-    return RepresentativeProfile(internal_convert.(ET, vals))
+    return RepresentativeProfile(_internal_convert.(ET, vals))
 end
-function internal_convert(
+function _internal_convert(
     ::Type{RepresentativeProfile{T,P}},
     rp::RepresentativeProfile{T,P},
 ) where {T,P<:TimeProfile{T}}
     return rp
 end
-internal_convert(::Type{T}, rp::RepresentativeProfile{T}) where {T} = rp
-function internal_convert(::Type{T}, rp::RepresentativeProfile{S}) where {T,S}
-    return RepresentativeProfile(internal_convert.(T, rp.vals))
+_internal_convert(::Type{T}, rp::RepresentativeProfile{T}) where {T} = rp
+function _internal_convert(::Type{T}, rp::RepresentativeProfile{S}) where {T,S}
+    return RepresentativeProfile(_internal_convert.(T, rp.vals))
 end
 
 function _value_lookup(::HasReprIndex, rp::RepresentativeProfile, period)
@@ -324,17 +324,17 @@ function StrategicStochasticProfile(vals::Vector{<:Vector{T}}) where {T}
 end
 function StrategicStochasticProfile(vals::Vector{<:Vector{T}}) where {T<:TimeProfile}
     ET = promote_type((profilevaluetype(v_2) for v_1 in vals for v_2 in v_1)...)
-    return StrategicStochasticProfile([internal_convert.(ET, v) for v in vals])
+    return StrategicStochasticProfile([_internal_convert.(ET, v) for v in vals])
 end
-function internal_convert(
+function _internal_convert(
     ::Type{StrategicStochasticProfile{T,P}},
     ssp::StrategicStochasticProfile{T,P},
 ) where {T,P<:TimeProfile{T}}
     return ssp
 end
-internal_convert(::Type{T}, ssp::StrategicStochasticProfile{T}) where {T} = ssp
-function internal_convert(::Type{T}, ssp::StrategicStochasticProfile{S}) where {T,S}
-    return StrategicStochasticProfile([internal_convert.(T, v) for v in ssp.vals])
+_internal_convert(::Type{T}, ssp::StrategicStochasticProfile{T}) where {T} = ssp
+function _internal_convert(::Type{T}, ssp::StrategicStochasticProfile{S}) where {T,S}
+    return StrategicStochasticProfile([_internal_convert.(T, v) for v in ssp.vals])
 end
 
 function _value_lookup(::HasStratTreeIndex, ssp::StrategicStochasticProfile, period)

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -34,10 +34,10 @@ function Base.getindex(
     return fp.val
 end
 
-_internal_convert(::Type{FixedProfile{T}}, fp::FixedProfile{T}) where {T} = fp
-function _internal_convert(::Type{FixedProfile{T}}, fp::FixedProfile{S}) where {T,S}
+function Base.convert(::Type{FixedProfile{T}}, fp::FixedProfile{S}) where {T,S}
     return FixedProfile(convert(T, fp.val))
 end
+_internal_convert(::Type{FixedProfile{T}}, fp::FixedProfile{T}) where {T} = fp
 function _internal_convert(::Type{T}, fp::FixedProfile{S}) where {T,S}
     return FixedProfile(convert(T, fp.val))
 end
@@ -79,13 +79,10 @@ function Base.getindex(op::OperationalProfile, i::TimeStructurePeriod)
     return error("Type $(typeof(i)) can not be used as index for an operational profile")
 end
 
-_internal_convert(::Type{OperationalProfile{T}}, op::OperationalProfile{T}) where {T} = op
-function _internal_convert(
-    ::Type{OperationalProfile{T}},
-    op::OperationalProfile{S},
-) where {T,S}
+function Base.convert(::Type{OperationalProfile{T}}, op::OperationalProfile{S}) where {T,S}
     return OperationalProfile(convert.(T, op.vals))
 end
+_internal_convert(::Type{OperationalProfile{T}}, op::OperationalProfile{T}) where {T} = op
 _internal_convert(::Type{T}, op::OperationalProfile{T}) where {T} = op
 function _internal_convert(::Type{T}, op::OperationalProfile{S}) where {T,S}
     return OperationalProfile(convert.(T, op.vals))

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -37,6 +37,7 @@ end
 function Base.convert(::Type{FixedProfile{T}}, fp::FixedProfile{S}) where {T,S}
     return FixedProfile(convert(T, fp.val))
 end
+_internal_convert(::Type{T}, fp::FixedProfile{T}) where {T} = fp
 function _internal_convert(::Type{T}, fp::FixedProfile{S}) where {T,S}
     return FixedProfile(convert(T, fp.val))
 end
@@ -81,6 +82,7 @@ end
 function Base.convert(::Type{OperationalProfile{T}}, op::OperationalProfile{S}) where {T,S}
     return OperationalProfile(convert.(T, op.vals))
 end
+_internal_convert(::Type{T}, op::OperationalProfile{T}) where {T} = op
 function _internal_convert(::Type{T}, op::OperationalProfile{S}) where {T,S}
     return OperationalProfile(convert.(T, op.vals))
 end
@@ -121,6 +123,7 @@ function StrategicProfile(vals::Vector{T}) where {T<:TimeProfile}
     return StrategicProfile(_internal_convert.(ET, vals))
 end
 
+_internal_convert(::Type{T}, sp::StrategicProfile{T}) where {T} = sp
 function _internal_convert(::Type{T}, sp::StrategicProfile{S}) where {T,S}
     return StrategicProfile(_internal_convert.(T, sp.vals))
 end
@@ -168,6 +171,7 @@ function ScenarioProfile(vals::Vector{T}) where {T<:TimeProfile}
     return ScenarioProfile(_internal_convert.(ET, vals))
 end
 
+_internal_convert(::Type{T}, sp::ScenarioProfile{T}) where {T} = sp
 function _internal_convert(::Type{T}, sp::ScenarioProfile{S}) where {T,S}
     return ScenarioProfile(_internal_convert.(T, sp.vals))
 end
@@ -239,6 +243,7 @@ function RepresentativeProfile(vals::Vector{T}) where {T<:TimeProfile}
     return RepresentativeProfile(_internal_convert.(ET, vals))
 end
 
+_internal_convert(::Type{T}, rp::RepresentativeProfile{T}) where {T} = rp
 function _internal_convert(::Type{T}, rp::RepresentativeProfile{S}) where {T,S}
     return RepresentativeProfile(_internal_convert.(T, rp.vals))
 end
@@ -303,6 +308,7 @@ function StrategicStochasticProfile(vals::Vector{<:Vector{T}}) where {T<:TimePro
     return StrategicStochasticProfile([_internal_convert.(ET, v) for v in vals])
 end
 
+_internal_convert(::Type{T}, ssp::StrategicStochasticProfile{T}) where {T} = ssp
 function _internal_convert(::Type{T}, ssp::StrategicStochasticProfile{S}) where {T,S}
     return StrategicStochasticProfile([_internal_convert.(T, v) for v in ssp.vals])
 end

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -37,7 +37,6 @@ end
 function Base.convert(::Type{FixedProfile{T}}, fp::FixedProfile{S}) where {T,S}
     return FixedProfile(convert(T, fp.val))
 end
-_internal_convert(::Type{FixedProfile{T}}, fp::FixedProfile{T}) where {T} = fp
 function _internal_convert(::Type{T}, fp::FixedProfile{S}) where {T,S}
     return FixedProfile(convert(T, fp.val))
 end
@@ -82,8 +81,6 @@ end
 function Base.convert(::Type{OperationalProfile{T}}, op::OperationalProfile{S}) where {T,S}
     return OperationalProfile(convert.(T, op.vals))
 end
-_internal_convert(::Type{OperationalProfile{T}}, op::OperationalProfile{T}) where {T} = op
-_internal_convert(::Type{T}, op::OperationalProfile{T}) where {T} = op
 function _internal_convert(::Type{T}, op::OperationalProfile{S}) where {T,S}
     return OperationalProfile(convert.(T, op.vals))
 end
@@ -123,13 +120,7 @@ function StrategicProfile(vals::Vector{T}) where {T<:TimeProfile}
     ET = promote_type((profilevaluetype(v) for v in vals)...)
     return StrategicProfile(_internal_convert.(ET, vals))
 end
-function _internal_convert(
-    ::Type{StrategicProfile{T,P}},
-    sp::StrategicProfile{T,P},
-) where {T,P<:TimeProfile{T}}
-    return sp
-end
-_internal_convert(::Type{T}, sp::StrategicProfile{T}) where {T} = sp
+
 function _internal_convert(::Type{T}, sp::StrategicProfile{S}) where {T,S}
     return StrategicProfile(_internal_convert.(T, sp.vals))
 end
@@ -176,13 +167,7 @@ function ScenarioProfile(vals::Vector{T}) where {T<:TimeProfile}
     ET = promote_type((profilevaluetype(v) for v in vals)...)
     return ScenarioProfile(_internal_convert.(ET, vals))
 end
-function _internal_convert(
-    ::Type{ScenarioProfile{T,P}},
-    sp::ScenarioProfile{T,P},
-) where {T,P<:TimeProfile{T}}
-    return sp
-end
-_internal_convert(::Type{T}, sp::ScenarioProfile{T}) where {T} = sp
+
 function _internal_convert(::Type{T}, sp::ScenarioProfile{S}) where {T,S}
     return ScenarioProfile(_internal_convert.(T, sp.vals))
 end
@@ -253,13 +238,7 @@ function RepresentativeProfile(vals::Vector{T}) where {T<:TimeProfile}
     ET = promote_type((profilevaluetype(v) for v in vals)...)
     return RepresentativeProfile(_internal_convert.(ET, vals))
 end
-function _internal_convert(
-    ::Type{RepresentativeProfile{T,P}},
-    rp::RepresentativeProfile{T,P},
-) where {T,P<:TimeProfile{T}}
-    return rp
-end
-_internal_convert(::Type{T}, rp::RepresentativeProfile{T}) where {T} = rp
+
 function _internal_convert(::Type{T}, rp::RepresentativeProfile{S}) where {T,S}
     return RepresentativeProfile(_internal_convert.(T, rp.vals))
 end
@@ -323,13 +302,7 @@ function StrategicStochasticProfile(vals::Vector{<:Vector{T}}) where {T<:TimePro
     ET = promote_type((profilevaluetype(v_2) for v_1 in vals for v_2 in v_1)...)
     return StrategicStochasticProfile([_internal_convert.(ET, v) for v in vals])
 end
-function _internal_convert(
-    ::Type{StrategicStochasticProfile{T,P}},
-    ssp::StrategicStochasticProfile{T,P},
-) where {T,P<:TimeProfile{T}}
-    return ssp
-end
-_internal_convert(::Type{T}, ssp::StrategicStochasticProfile{T}) where {T} = ssp
+
 function _internal_convert(::Type{T}, ssp::StrategicStochasticProfile{S}) where {T,S}
     return StrategicStochasticProfile([_internal_convert.(T, v) for v in ssp.vals])
 end

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -34,11 +34,11 @@ function Base.getindex(
     return fp.val
 end
 
-Base.convert(::Type{FixedProfile{T}}, fp::FixedProfile{T}) where {T} = fp
-function Base.convert(::Type{FixedProfile{T}}, fp::FixedProfile{S}) where {T,S}
+internal_convert(::Type{FixedProfile{T}}, fp::FixedProfile{T}) where {T} = fp
+function internal_convert(::Type{FixedProfile{T}}, fp::FixedProfile{S}) where {T,S}
     return FixedProfile(convert(T, fp.val))
 end
-function Base.convert(::Type{T}, fp::FixedProfile{S}) where {T,S}
+function internal_convert(::Type{T}, fp::FixedProfile{S}) where {T,S}
     return FixedProfile(convert(T, fp.val))
 end
 
@@ -79,12 +79,15 @@ function Base.getindex(op::OperationalProfile, i::TimeStructurePeriod)
     return error("Type $(typeof(i)) can not be used as index for an operational profile")
 end
 
-Base.convert(::Type{OperationalProfile{T}}, op::OperationalProfile{T}) where {T} = op
-function Base.convert(::Type{OperationalProfile{T}}, op::OperationalProfile{S}) where {T,S}
+internal_convert(::Type{OperationalProfile{T}}, op::OperationalProfile{T}) where {T} = op
+function internal_convert(
+    ::Type{OperationalProfile{T}},
+    op::OperationalProfile{S},
+) where {T,S}
     return OperationalProfile(convert.(T, op.vals))
 end
-Base.convert(::Type{T}, op::OperationalProfile{T}) where {T} = op
-function Base.convert(::Type{T}, op::OperationalProfile{S}) where {T,S}
+internal_convert(::Type{T}, op::OperationalProfile{T}) where {T} = op
+function internal_convert(::Type{T}, op::OperationalProfile{S}) where {T,S}
     return OperationalProfile(convert.(T, op.vals))
 end
 
@@ -121,17 +124,17 @@ function StrategicProfile(vals::Vector{T}) where {T}
 end
 function StrategicProfile(vals::Vector{T}) where {T<:TimeProfile}
     ET = promote_type((profilevaluetype(v) for v in vals)...)
-    return StrategicProfile(convert.(ET, vals))
+    return StrategicProfile(internal_convert.(ET, vals))
 end
-function Base.convert(
+function internal_convert(
     ::Type{StrategicProfile{T,P}},
     sp::StrategicProfile{T,P},
 ) where {T,P<:TimeProfile{T}}
     return sp
 end
-Base.convert(::Type{T}, sp::StrategicProfile{T}) where {T} = sp
-function Base.convert(::Type{T}, sp::StrategicProfile{S}) where {T,S}
-    return StrategicProfile(convert.(T, sp.vals))
+internal_convert(::Type{T}, sp::StrategicProfile{T}) where {T} = sp
+function internal_convert(::Type{T}, sp::StrategicProfile{S}) where {T,S}
+    return StrategicProfile(internal_convert.(T, sp.vals))
 end
 
 function _value_lookup(::HasStratIndex, sp::StrategicProfile, period)
@@ -174,17 +177,17 @@ end
 
 function ScenarioProfile(vals::Vector{T}) where {T<:TimeProfile}
     ET = promote_type((profilevaluetype(v) for v in vals)...)
-    return ScenarioProfile(convert.(ET, vals))
+    return ScenarioProfile(internal_convert.(ET, vals))
 end
-function Base.convert(
+function internal_convert(
     ::Type{ScenarioProfile{T,P}},
     sp::ScenarioProfile{T,P},
 ) where {T,P<:TimeProfile{T}}
     return sp
 end
-Base.convert(::Type{T}, sp::ScenarioProfile{T}) where {T} = sp
-function Base.convert(::Type{T}, sp::ScenarioProfile{S}) where {T,S}
-    return ScenarioProfile(convert.(T, sp.vals))
+internal_convert(::Type{T}, sp::ScenarioProfile{T}) where {T} = sp
+function internal_convert(::Type{T}, sp::ScenarioProfile{S}) where {T,S}
+    return ScenarioProfile(internal_convert.(T, sp.vals))
 end
 
 function ScenarioProfile(vals::Vector{T}) where {T}
@@ -251,17 +254,17 @@ function RepresentativeProfile(vals::Vector{T}) where {T}
 end
 function RepresentativeProfile(vals::Vector{T}) where {T<:TimeProfile}
     ET = promote_type((profilevaluetype(v) for v in vals)...)
-    return RepresentativeProfile(convert.(ET, vals))
+    return RepresentativeProfile(internal_convert.(ET, vals))
 end
-function Base.convert(
+function internal_convert(
     ::Type{RepresentativeProfile{T,P}},
     rp::RepresentativeProfile{T,P},
 ) where {T,P<:TimeProfile{T}}
     return rp
 end
-Base.convert(::Type{T}, rp::RepresentativeProfile{T}) where {T} = rp
-function Base.convert(::Type{T}, rp::RepresentativeProfile{S}) where {T,S}
-    return RepresentativeProfile(convert.(T, rp.vals))
+internal_convert(::Type{T}, rp::RepresentativeProfile{T}) where {T} = rp
+function internal_convert(::Type{T}, rp::RepresentativeProfile{S}) where {T,S}
+    return RepresentativeProfile(internal_convert.(T, rp.vals))
 end
 
 function _value_lookup(::HasReprIndex, rp::RepresentativeProfile, period)
@@ -321,17 +324,17 @@ function StrategicStochasticProfile(vals::Vector{<:Vector{T}}) where {T}
 end
 function StrategicStochasticProfile(vals::Vector{<:Vector{T}}) where {T<:TimeProfile}
     ET = promote_type((profilevaluetype(v_2) for v_1 in vals for v_2 in v_1)...)
-    return StrategicStochasticProfile([convert.(ET, v) for v in vals])
+    return StrategicStochasticProfile([internal_convert.(ET, v) for v in vals])
 end
-function Base.convert(
+function internal_convert(
     ::Type{StrategicStochasticProfile{T,P}},
     ssp::StrategicStochasticProfile{T,P},
 ) where {T,P<:TimeProfile{T}}
     return ssp
 end
-Base.convert(::Type{T}, ssp::StrategicStochasticProfile{T}) where {T} = ssp
-function Base.convert(::Type{T}, ssp::StrategicStochasticProfile{S}) where {T,S}
-    return StrategicStochasticProfile([convert.(T, v) for v in ssp.vals])
+internal_convert(::Type{T}, ssp::StrategicStochasticProfile{T}) where {T} = ssp
+function internal_convert(::Type{T}, ssp::StrategicStochasticProfile{S}) where {T,S}
+    return StrategicStochasticProfile([internal_convert.(T, v) for v in ssp.vals])
 end
 
 function _value_lookup(::HasStratTreeIndex, ssp::StrategicStochasticProfile, period)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1201,30 +1201,42 @@ end
 
 @testitem "Profile conversion" begin
     fp = FixedProfile(12)
+    @test TimeStruct._internal_convert(Int64, fp) == FixedProfile(12)
     @test TimeStruct._internal_convert(Float64, fp) == FixedProfile(12.0)
 
     op_int = OperationalProfile([1, 2, 3])
     op_float = TimeStruct._internal_convert(Float64, op_int)
     @test typeof(op_float) == OperationalProfile{Float64}
+    op_int = TimeStruct._internal_convert(Int64, op_int)
+    @test TimeStruct.profilevaluetype(op_int) == Int64
 
     sp = ScenarioProfile([op_int, op_float])
     @test TimeStruct.profilevaluetype(sp) == Float64
     sp_int = TimeStruct._internal_convert(Int64, sp)
+    @test TimeStruct.profilevaluetype(sp_int) == Int64
+    sp_int = TimeStruct._internal_convert(Int64, sp_int)
     @test TimeStruct.profilevaluetype(sp_int) == Int64
 
     rp = RepresentativeProfile([sp, sp_int])
     @test TimeStruct.profilevaluetype(rp) == Float64
     rp_int = TimeStruct._internal_convert(Int64, rp)
     @test TimeStruct.profilevaluetype(rp_int) == Int64
+    rp_int = TimeStruct._internal_convert(Int64, rp_int)
+    @test TimeStruct.profilevaluetype(rp_int) == Int64
+
 
     stp = StrategicProfile([sp, rp, 2 * rp])
     @test TimeStruct.profilevaluetype(stp) == Float64
     stp_int = TimeStruct._internal_convert(Int64, stp)
     @test TimeStruct.profilevaluetype(stp_int) == Int64
+    stp_int = TimeStruct._internal_convert(Int64, stp_int)
+    @test TimeStruct.profilevaluetype(stp_int) == Int64
 
     ssp = StrategicStochasticProfile([[sp, rp], [2 * sp, 3 * rp]])
     @test TimeStruct.profilevaluetype(ssp) == Float64
     ssp_int = TimeStruct._internal_convert(Int64, ssp)
+    @test TimeStruct.profilevaluetype(ssp_int) == Int64
+    ssp_int = TimeStruct._internal_convert(Int64, ssp_int)
     @test TimeStruct.profilevaluetype(ssp_int) == Int64
 
     v = [FixedProfile(1.0)]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1224,7 +1224,6 @@ end
     rp_int = TimeStruct._internal_convert(Int64, rp_int)
     @test TimeStruct.profilevaluetype(rp_int) == Int64
 
-
     stp = StrategicProfile([sp, rp, 2 * rp])
     @test TimeStruct.profilevaluetype(stp) == Float64
     stp_int = TimeStruct._internal_convert(Int64, stp)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1201,30 +1201,30 @@ end
 
 @testitem "Profile conversion" begin
     fp = FixedProfile(12)
-    @test convert(Float64, fp) == FixedProfile(12.0)
+    @test TimeStruct._internal_convert(Float64, fp) == FixedProfile(12.0)
 
     op_int = OperationalProfile([1, 2, 3])
-    op_float = convert(Float64, op_int)
+    op_float = TimeStruct._internal_convert(Float64, op_int)
     @test typeof(op_float) == OperationalProfile{Float64}
 
     sp = ScenarioProfile([op_int, op_float])
     @test TimeStruct.profilevaluetype(sp) == Float64
-    sp_int = convert(Int64, sp)
+    sp_int = TimeStruct._internal_convert(Int64, sp)
     @test TimeStruct.profilevaluetype(sp_int) == Int64
 
     rp = RepresentativeProfile([sp, sp_int])
     @test TimeStruct.profilevaluetype(rp) == Float64
-    rp_int = convert(Int64, rp)
+    rp_int = TimeStruct._internal_convert(Int64, rp)
     @test TimeStruct.profilevaluetype(rp_int) == Int64
 
     stp = StrategicProfile([sp, rp, 2 * rp])
     @test TimeStruct.profilevaluetype(stp) == Float64
-    stp_int = convert(Int64, stp)
+    stp_int = TimeStruct._internal_convert(Int64, stp)
     @test TimeStruct.profilevaluetype(stp_int) == Int64
 
     ssp = StrategicStochasticProfile([[sp, rp], [2 * sp, 3 * rp]])
     @test TimeStruct.profilevaluetype(ssp) == Float64
-    ssp_int = convert(Int64, ssp)
+    ssp_int = TimeStruct._internal_convert(Int64, ssp)
     @test TimeStruct.profilevaluetype(ssp_int) == Int64
 
     v = [FixedProfile(1.0)]


### PR DESCRIPTION
This PR should fix #65. The solution is to rename the internal conversion functions to `internal_convert`.