### PR TITLE
Enhance discount_avg function to support resolution parameter

### DIFF
--- a/src/discount.jl
+++ b/src/discount.jl
@@ -123,7 +123,14 @@ end
 
 Returns an overall weight to be used for a time period `t`
 in the objective function considering both discounting,
-probability and possible multiplicity.
+probability and possible multiplicity. There are two types of discounting
+available, either discounting to the start of the strategic period
+containing the time period (`type="start"`) or calculating an approximate
+value for the average discount factor over the whole strategic period.
+The average can be calculated either as a continuous average (`type="avg"`) or
+as a discrete average that discounts to the start of each year (`type="avg_year"`).
+The `timeunit_to_year` parameter is used to convert the time units of
+strategic periods in the time structure to years (default value = 1.0).
 """
 function objective_weight(
     t::TimePeriod,

--- a/src/discount.jl
+++ b/src/discount.jl
@@ -76,16 +76,15 @@ function discount(disc::Discounter, t::TimePeriod; type = "start", timeunit_to_y
     return discount(t, disc.ts, disc.discount_rate; type, timeunit_to_year)
 end
 
-function discount_avg(discount_rate, start_year, duration_years)
-    if discount_rate > 0
-        δ = 1 / (1 + discount_rate)
-        m =
-            (δ^start_year - δ^(start_year + duration_years)) / log(1 + discount_rate) /
-            duration_years
-        return m
-    else
-        return 1.0
+function discount_avg(discount_rate, start_year, duration_years; resolution::Int = 0)
+    discount_rate == 0 && return 1.0
+    δ = 1 / (1 + discount_rate)
+    if resolution == 0
+        return (δ^start_year - δ^(start_year + duration_years)) / log(1 + discount_rate) /
+               duration_years
     end
+    return sum(δ^(start_year + i / resolution) for i in 0:(resolution*duration_years-1)) /
+           (resolution * duration_years)
 end
 
 function discount_start(discount_rate, start_year)
@@ -107,6 +106,8 @@ function discount(
         return discount_start(discount_rate, start_year)
     elseif type == "avg"
         return discount_avg(discount_rate, start_year, duration_years)
+    elseif type == "avg_year"
+        return discount_avg(discount_rate, start_year, duration_years; resolution = 1)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1335,6 +1335,11 @@ end
         @test discount(disc, t) == δ^(i - 1)
     end
 
+    for sp in strat_periods(uniform_years)
+        @test discount(sp, uniform_years, 0.06; type = "avg") <
+              discount(sp, uniform_years, 0.06; type = "avg_year")
+    end
+
     @test sum(objective_weight(t, disc) for t in uniform_years) ≈ 8.435 atol = 1e-3
 
     uniform_day = SimpleTimes(24, 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1335,20 +1335,30 @@ end
         @test discount(disc, t) == δ^(i - 1)
     end
 
-    for sp in strat_periods(uniform_years)
-        @test discount(sp, uniform_years, 0.06; type = "avg") <
-              discount(sp, uniform_years, 0.06; type = "avg_year")
-    end
+    @test sum(
+        discount(sp, uniform_years, 0.06; type = "avg_year") for
+        sp in strat_periods(uniform_years)
+    ) ≈ 7.8017 atol = 1e-3
 
     @test sum(objective_weight(t, disc) for t in uniform_years) ≈ 8.435 atol = 1e-3
 
     uniform_day = SimpleTimes(24, 1)
-    periods = TwoLevel(10, 8760, uniform_day)
+    periods = TwoLevel(10, 5 * 8760, uniform_day)
 
     @test sum(
-        objective_weight(sp, periods, 0.04; timeunit_to_year = 1 / 8760) for
+        objective_weight(sp, periods, 0.04; timeunit_to_year = 1 / 8760, type = "start") for
         sp in strat_periods(periods)
-    ) ≈ 8.435 atol = 1e-3
+    ) ≈ 4.825 atol = 1e-3
+
+    @test sum(
+        objective_weight(sp, periods, 0.04; timeunit_to_year = 1 / 8760, type = "avg_year")
+        for sp in strat_periods(periods)
+    ) ≈ 4.468 atol = 1e-3
+
+    @test sum(
+        objective_weight(sp, periods, 0.04; timeunit_to_year = 1 / 8760, type = "avg") for
+        sp in strat_periods(periods)
+    ) ≈ 4.382 atol = 1e-3
 
     uniform_day = SimpleTimes(24, 1u"hr")
     periods_unit = TwoLevel(10, 365.125u"d", uniform_day)


### PR DESCRIPTION
Working with OpenEMPIRE code, there was a need to support additional discount calculations. I am not totally happy with using 0 as a default value for the `resolution` parameter to indicate a continuous calculation (I would prefer Inf, but that would mean having to convert from a float somewhere).