### PR TITLE
Addition and subtraction of time profiles

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TimeStruct"
 uuid = "f9ed5ce0-9f41-4eaa-96da-f38ab8df101c"
 authors = ["Lars Hellemo <Lars.Hellemo@sintef.no>, Truls.Flatberg <Truls.Flatberg@sintef.no>"]
-version = "0.9.9"
+version = "0.9.10"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -416,3 +416,51 @@ end
 -(a::RepresentativeProfile{T}) where {T} = RepresentativeProfile(-a.vals)
 
 +(a::TimeProfile{T}) where {T} = a
+
+function +(a::FixedProfile{T}, b::FixedProfile{S}) where {T,S}
+    return FixedProfile(a.val + b.val)
+end
+function +(a::OperationalProfile{T}, b::OperationalProfile{S}) where {T,S}
+    return OperationalProfile(a.vals .+ b.vals)
+end
+function +(a::StrategicProfile{T}, b::StrategicProfile{S}) where {T,S}
+    return StrategicProfile(a.vals .+ b.vals)
+end
+function +(a::ScenarioProfile{T}, b::ScenarioProfile{S}) where {T,S}
+    return ScenarioProfile(a.vals .+ b.vals)
+end
+function +(a::RepresentativeProfile{T}, b::RepresentativeProfile{S}) where {T,S}
+    return RepresentativeProfile(a.vals .+ b.vals)
+end
+
+function +(a::StrategicProfile{T}, b::OperationalProfile{S}) where {T,S}
+    return StrategicProfile([p + b for p in a.vals])
+end
++(a::OperationalProfile{T}, b::StrategicProfile{S}) where {T,S} = b + a
+function +(a::ScenarioProfile{T}, b::OperationalProfile{S}) where {T,S}
+    return ScenarioProfile([p + b for p in a.vals])
+end
++(a::OperationalProfile{T}, b::ScenarioProfile{S}) where {T,S} = b + a
+function +(a::RepresentativeProfile{T}, b::OperationalProfile{S}) where {T,S}
+    return RepresentativeProfile([p + b for p in a.vals])
+end
++(a::OperationalProfile{T}, b::RepresentativeProfile{S}) where {T,S} = b + a
+
+function +(a::FixedProfile{T}, b::OperationalProfile{S}) where {T,S}
+    return OperationalProfile(a.val .+ b.vals)
+end
++(a::OperationalProfile{T}, b::FixedProfile{S}) where {T,S} = b + a
+function +(a::FixedProfile{T}, b::StrategicProfile{S}) where {T,S}
+    return StrategicProfile([a + p for p in b.vals])
+end
++(a::StrategicProfile{T}, b::FixedProfile{S}) where {T,S} = b + a
+function +(a::FixedProfile{T}, b::ScenarioProfile{S}) where {T,S}
+    return ScenarioProfile([a + p for p in b.vals])
+end
++(a::ScenarioProfile{T}, b::FixedProfile{S}) where {T,S} = b + a
+function +(a::FixedProfile{T}, b::RepresentativeProfile{S}) where {T,S}
+    return RepresentativeProfile([a + p for p in b.vals])
+end
++(a::RepresentativeProfile{T}, b::FixedProfile{S}) where {T,S} = b + a
+
+-(a::TimeProfile{T}, b::TimeProfile{S}) where {T,S} = a + (-b)

--- a/src/profiles.jl
+++ b/src/profiles.jl
@@ -365,6 +365,9 @@ end
 function +(a::RepresentativeProfile{T}, b::Number) where {T}
     return RepresentativeProfile(a.vals .+ b)
 end
+function +(a::StrategicStochasticProfile{T}, b::Number) where {T}
+    return StrategicStochasticProfile([v .+ b for v in a.vals])
+end
 +(a::Number, b::TimeProfile{T}) where {T} = b + a
 -(a::FixedProfile{T}, b::Number) where {T} = FixedProfile(a.val - b)
 function -(a::OperationalProfile{T}, b::Number) where {T}
@@ -379,6 +382,9 @@ end
 function -(a::RepresentativeProfile{T}, b::Number) where {T}
     return RepresentativeProfile(a.vals .- b)
 end
+function -(a::StrategicStochasticProfile{T}, b::Number) where {T}
+    return StrategicStochasticProfile([v .- b for v in a.vals])
+end
 
 *(a::FixedProfile{T}, b::Number) where {T} = FixedProfile(a.val .* b)
 function *(a::OperationalProfile{T}, b::Number) where {T}
@@ -392,6 +398,9 @@ function *(a::ScenarioProfile{T}, b::Number) where {T}
 end
 function *(a::RepresentativeProfile{T}, b::Number) where {T}
     return RepresentativeProfile(a.vals .* b)
+end
+function *(a::StrategicStochasticProfile{T}, b::Number) where {T}
+    return StrategicStochasticProfile([v .* b for v in a.vals])
 end
 
 *(a::Number, b::TimeProfile{T}) where {T} = b * a
@@ -408,12 +417,17 @@ end
 function /(a::RepresentativeProfile{T}, b::Number) where {T}
     return RepresentativeProfile(a.vals ./ b)
 end
+function /(a::StrategicStochasticProfile{T}, b::Number) where {T}
+    return StrategicStochasticProfile([v ./ b for v in a.vals])
+end
 
 -(a::FixedProfile{T}) where {T} = FixedProfile(-a.val)
 -(a::OperationalProfile{T}) where {T} = OperationalProfile(-a.vals)
 -(a::StrategicProfile{T}) where {T} = StrategicProfile(-a.vals)
 -(a::ScenarioProfile{T}) where {T} = ScenarioProfile(-a.vals)
 -(a::RepresentativeProfile{T}) where {T} = RepresentativeProfile(-a.vals)
+-(a::StrategicStochasticProfile{T}) where {T} =
+    StrategicStochasticProfile([.-v for v in a.vals])
 
 +(a::TimeProfile{T}) where {T} = a
 
@@ -431,6 +445,9 @@ function +(a::ScenarioProfile{T}, b::ScenarioProfile{S}) where {T,S}
 end
 function +(a::RepresentativeProfile{T}, b::RepresentativeProfile{S}) where {T,S}
     return RepresentativeProfile(a.vals .+ b.vals)
+end
+function +(a::StrategicStochasticProfile{T}, b::StrategicStochasticProfile{S}) where {T,S}
+    return StrategicStochasticProfile([va .+ vb for (va, vb) in zip(a.vals, b.vals)])
 end
 
 function +(a::StrategicProfile{T}, b::OperationalProfile{S}) where {T,S}
@@ -462,5 +479,13 @@ function +(a::FixedProfile{T}, b::RepresentativeProfile{S}) where {T,S}
     return RepresentativeProfile([a + p for p in b.vals])
 end
 +(a::RepresentativeProfile{T}, b::FixedProfile{S}) where {T,S} = b + a
+function +(a::StrategicStochasticProfile{T}, b::OperationalProfile{S}) where {T,S}
+    return StrategicStochasticProfile([[p + b for p in v] for v in a.vals])
+end
++(a::OperationalProfile{T}, b::StrategicStochasticProfile{S}) where {T,S} = b + a
+function +(a::FixedProfile{T}, b::StrategicStochasticProfile{S}) where {T,S}
+    return StrategicStochasticProfile([[a + p for p in v] for v in b.vals])
+end
++(a::StrategicStochasticProfile{T}, b::FixedProfile{S}) where {T,S} = b + a
 
 -(a::TimeProfile{T}, b::TimeProfile{S}) where {T,S} = a + (-b)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1535,6 +1535,98 @@ end
     @test vals == [-1, -2, -1, -2, -1, -2]
 end
 
+@testitem "Profile addition and subtraction" begin
+    day = SimpleTimes(5, 1)
+    ts_strat = TwoLevel(3, 10, SimpleTimes(5, 1))
+    ts_scen = TwoLevel(2, 10, OperationalScenarios(3, SimpleTimes(5, 1)))
+    ts_repr = TwoLevel(
+        2,
+        5,
+        RepresentativePeriods(2, 5, [0.5, 0.5], [SimpleTimes(5, 1), SimpleTimes(5, 1)]),
+    )
+
+    fp = FixedProfile(3)
+    fp2 = FixedProfile(10)
+    op = OperationalProfile([1, 2, 3, 4, 5])
+    op2 = OperationalProfile([6, 7, 8, 9, 10])
+    sp = StrategicProfile([
+        OperationalProfile([1, 2, 3, 4, 5]),
+        OperationalProfile([6, 7, 8, 9, 10]),
+        FixedProfile(2),
+    ])
+    sp2 = StrategicProfile([FixedProfile(1), FixedProfile(2), FixedProfile(3)])
+    scp = ScenarioProfile([
+        OperationalProfile([1, 2, 3, 4, 5]),
+        OperationalProfile([6, 7, 8, 9, 10]),
+        FixedProfile(2),
+    ])
+    scp2 = ScenarioProfile([FixedProfile(1), FixedProfile(2), FixedProfile(3)])
+    rp = RepresentativeProfile([
+        OperationalProfile([1, 2, 3, 4, 5]),
+        OperationalProfile([6, 7, 8, 9, 10]),
+    ])
+    rp2 = RepresentativeProfile([FixedProfile(1), FixedProfile(2)])
+
+    # FixedProfile + FixedProfile
+    @test all((fp+fp2)[t] == fp[t] + fp2[t] for t in day)
+    @test all((fp+fp2)[t] == (fp2+fp)[t] for t in day)
+
+    # OperationalProfile + OperationalProfile
+    @test all((op+op2)[t] == op[t] + op2[t] for t in day)
+    @test all((op+op2)[t] == (op2+op)[t] for t in day)
+
+    # FixedProfile + OperationalProfile
+    @test all((fp+op)[t] == fp[t] + op[t] for t in day)
+    @test all((fp+op)[t] == (op+fp)[t] for t in day)
+
+    # StrategicProfile + StrategicProfile
+    @test all((sp+sp2)[t] == sp[t] + sp2[t] for t in ts_strat)
+    @test all((sp+sp2)[t] == (sp2+sp)[t] for t in ts_strat)
+
+    # StrategicProfile + OperationalProfile
+    @test all((sp+op)[t] == sp[t] + op[t] for t in ts_strat)
+    @test all((sp+op)[t] == (op+sp)[t] for t in ts_strat)
+
+    # FixedProfile + StrategicProfile
+    @test all((fp+sp)[t] == fp[t] + sp[t] for t in ts_strat)
+    @test all((fp+sp)[t] == (sp+fp)[t] for t in ts_strat)
+
+    # ScenarioProfile + ScenarioProfile
+    @test all((scp+scp2)[t] == scp[t] + scp2[t] for t in ts_scen)
+    @test all((scp+scp2)[t] == (scp2+scp)[t] for t in ts_scen)
+
+    # ScenarioProfile + OperationalProfile
+    @test all((scp+op)[t] == scp[t] + op[t] for t in ts_scen)
+    @test all((scp+op)[t] == (op+scp)[t] for t in ts_scen)
+
+    # FixedProfile + ScenarioProfile
+    @test all((fp+scp)[t] == fp[t] + scp[t] for t in ts_scen)
+    @test all((fp+scp)[t] == (scp+fp)[t] for t in ts_scen)
+
+    # RepresentativeProfile + RepresentativeProfile
+    @test all((rp+rp2)[t] == rp[t] + rp2[t] for t in ts_repr)
+    @test all((rp+rp2)[t] == (rp2+rp)[t] for t in ts_repr)
+
+    # RepresentativeProfile + OperationalProfile
+    @test all((rp+op)[t] == rp[t] + op[t] for t in ts_repr)
+    @test all((rp+op)[t] == (op+rp)[t] for t in ts_repr)
+
+    # FixedProfile + RepresentativeProfile
+    @test all((fp+rp)[t] == fp[t] + rp[t] for t in ts_repr)
+    @test all((fp+rp)[t] == (rp+fp)[t] for t in ts_repr)
+
+    # Subtraction: a - b = a + (-b), spot-check across profile type pairs
+    @test all((fp-fp2)[t] == fp[t] - fp2[t] for t in day)
+    @test all((op-fp)[t] == op[t] - fp[t] for t in day)
+    @test all((fp-op)[t] == fp[t] - op[t] for t in day)
+    @test all((sp-op)[t] == sp[t] - op[t] for t in ts_strat)
+    @test all((fp-sp)[t] == fp[t] - sp[t] for t in ts_strat)
+    @test all((scp-op)[t] == scp[t] - op[t] for t in ts_scen)
+    @test all((fp-scp)[t] == fp[t] - scp[t] for t in ts_scen)
+    @test all((rp-op)[t] == rp[t] - op[t] for t in ts_repr)
+    @test all((fp-rp)[t] == fp[t] - rp[t] for t in ts_repr)
+end
+
 @testitem "Iteration utilities" begin
     uniform_day = SimpleTimes(24, 1)
     uniform_week = TwoLevel(7, 24, uniform_day)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1533,6 +1533,16 @@ end
     profile = -RepresentativeProfile([1, 2, 3])
     vals = collect(profile[rp] for rp in repr_periods(ts))
     @test vals == [-1, -2, -1, -2, -1, -2]
+
+    # StrategicStochasticProfile
+    tree = TwoLevelTree(5, [3, 2], SimpleTimes(5, 1))
+    ssp_unary = StrategicStochasticProfile([[1], [2, 3, 4], [5, 6, 7, 8, 9, 10]])
+
+    profile = +ssp_unary
+    @test all(profile[n] == ssp_unary[n] for n in strat_nodes(tree))
+
+    profile = -ssp_unary
+    @test all(profile[n] == -ssp_unary[n] for n in strat_nodes(tree))
 end
 
 @testitem "Profile addition and subtraction" begin
@@ -1625,6 +1635,68 @@ end
     @test all((fp-scp)[t] == fp[t] - scp[t] for t in ts_scen)
     @test all((rp-op)[t] == rp[t] - op[t] for t in ts_repr)
     @test all((fp-rp)[t] == fp[t] - rp[t] for t in ts_repr)
+
+    # StrategicStochasticProfile setup
+    tree = TwoLevelTree(5, [3, 2], SimpleTimes(5, 1))
+    ssp = StrategicStochasticProfile([
+        [OperationalProfile([1, 2, 3, 4, 5])],
+        [
+            OperationalProfile([2, 3, 4, 5, 6]),
+            OperationalProfile([3, 4, 5, 6, 7]),
+            OperationalProfile([4, 5, 6, 7, 8]),
+        ],
+        [
+            OperationalProfile([5, 6, 7, 8, 9]),
+            OperationalProfile([6, 7, 8, 9, 10]),
+            OperationalProfile([7, 8, 9, 10, 11]),
+            OperationalProfile([8, 9, 10, 11, 12]),
+            OperationalProfile([9, 10, 11, 12, 13]),
+            OperationalProfile([10, 11, 12, 13, 14]),
+        ],
+    ])
+    ssp2 = StrategicStochasticProfile([
+        [FixedProfile(1)],
+        [FixedProfile(2), FixedProfile(3), FixedProfile(4)],
+        [
+            FixedProfile(5),
+            FixedProfile(6),
+            FixedProfile(7),
+            FixedProfile(8),
+            FixedProfile(9),
+            FixedProfile(10),
+        ],
+    ])
+
+    # StrategicStochasticProfile + Number
+    @test all((ssp+10)[t] == ssp[t] + 10 for t in tree)
+    @test all((10+ssp)[t] == ssp[t] + 10 for t in tree)
+
+    # StrategicStochasticProfile - Number
+    @test all((ssp-1)[t] == ssp[t] - 1 for t in tree)
+
+    # StrategicStochasticProfile * Number
+    @test all((ssp*2)[t] == ssp[t] * 2 for t in tree)
+    @test all((2*ssp)[t] == ssp[t] * 2 for t in tree)
+
+    # StrategicStochasticProfile / Number
+    @test all((ssp/2)[t] == ssp[t] / 2 for t in tree)
+
+    # StrategicStochasticProfile + StrategicStochasticProfile
+    @test all((ssp+ssp2)[t] == ssp[t] + ssp2[t] for t in tree)
+    @test all((ssp+ssp2)[t] == (ssp2+ssp)[t] for t in tree)
+
+    # StrategicStochasticProfile + OperationalProfile
+    @test all((ssp+op)[t] == ssp[t] + op[t] for t in tree)
+    @test all((ssp+op)[t] == (op+ssp)[t] for t in tree)
+
+    # FixedProfile + StrategicStochasticProfile
+    @test all((fp+ssp)[t] == fp[t] + ssp[t] for t in tree)
+    @test all((fp+ssp)[t] == (ssp+fp)[t] for t in tree)
+
+    # StrategicStochasticProfile subtraction (via unary -)
+    @test all((ssp-ssp2)[t] == ssp[t] - ssp2[t] for t in tree)
+    @test all((ssp-op)[t] == ssp[t] - op[t] for t in tree)
+    @test all((fp-ssp)[t] == fp[t] - ssp[t] for t in tree)
 end
 
 @testitem "Iteration utilities" begin


### PR DESCRIPTION
Initial attempt at better support for addition and subtraction of time profiles (see #91). 

There is still some open questions to be discussed.
- Should there be more explicit errors for addition of profiles not supported (e.g. `ScenarioProfile` + `RepresentativeProfile`) or should we make the effort to support all combinations? 
- Should arithmetic support also be extended to `StrategicStochasticProfile`?

There is also the question about changing the behavior of what to do when using too short profiles for a time structure. Should we return an error instead of repeating the last, as we do today? This will be a breaking change so I think we should consider it for a separate PR.  
